### PR TITLE
Logname implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Contributions are welcome!
 
 Please only contribute versions of the original utilities written in V.  Contributions written in other langauges will likely be rejected.
 
-## Completed (4/109)
+## Completed (5/109)
 
 | Done    | Cmd       | Descripton                                       |
 | :-----: |-----------|--------------------------------------------------|
@@ -70,7 +70,7 @@ Please only contribute versions of the original utilities written in V.  Contrib
 |         | kill      | Send a signal to processes                       |
 |         | link      | Make a hard link via the link syscall            |
 |         | ln        | Make links between files                         |
-|         | logname   | Print current login name                         |
+| &check; | logname   | Print current login name                         |
 |         | ls        | List directory contents                          |
 |         | md5sum    | Print or check MD5 digests                       |
 |         | mkdir     | Make directories                                 |

--- a/logname/logname.v
+++ b/logname/logname.v
@@ -1,0 +1,63 @@
+import os
+
+/* logname
+** VinWare, 2021-07-05 05:00:00 UTC
+**
+** Basic implementation of logname
+** Does not specify ENV variables
+** Follows POSIX (uses C getlogin)
+** 
+** Remaining issues:
+** Standard error messages
+** Standard way to take arguments
+*/
+
+fn try(arg string) string {
+	line1 := 'Unknown argument: ' + arg
+	line2 := 'Use logname --help to see options'
+	return line1 + '\n' + line2
+}
+fn unrec(arg string) string {
+	line1 := 'logname: unrecognized option ' + arg
+	line2 := 'Use logname --help to see options'
+	return line1 + '\n' + line2
+}
+fn error_exit(error string) {
+	eprintln(error)
+	exit(1) 
+}
+fn main() {
+	usage := 'Usage: logname [OPTION]. [OPTION] can be --help, --version'
+	version := 'logname (V coreutils) 0.0.1'
+	args := os.args[1..]
+	params := args.filter(it.len > 2 && it[0..2] == '--')
+	if params.len > 0 {
+		// Parameters provided
+		match params[0] {
+			'--help' {
+				println(usage)
+				exit(0)
+			}
+			'--version' {
+				println(version)
+				exit(0)
+			}
+			else {
+				error_exit(unrec(params[0]))
+			}
+		}
+		exit(0)
+	}
+	if args.len > 0 {
+		// Unnecessary argument
+		error_exit(try(args[0]))
+	} 
+	// Main functionality
+	// Internally uses C.getlogin
+	lname := os.loginname()
+	if lname == '' {
+		// C.getlogin failed
+		error_exit('no login name')
+	}
+	println(lname)
+}


### PR DESCRIPTION
Contains a simple implementation of logname (POSIX compliant)

1. Uses os.loginname, as that uses C.getlogin internally
2. Works for standard arguments as in GNU coreutils
3. Shows basic error/info messages