### PR TITLE
Improvements to logname

### DIFF
--- a/logname/logname.v
+++ b/logname/logname.v
@@ -1,5 +1,5 @@
 import os
-
+import flag
 /* logname
 ** VinWare, 2021-07-05 05:00:00 UTC
 **
@@ -24,9 +24,30 @@ fn unrec(arg string) string {
 }
 fn error_exit(error string) {
 	eprintln(error)
-	exit(1) 
+	exit(1) 	
 }
 fn main() {
+	// Flags
+	mut fp := flag.new_flag_parser(os.args)
+	fp.application('logname')
+	// fp.limit_free_args(0,0)
+	help := fp.bool('help',0,false,'display this help and exit')
+	version := fp.bool('version',0,false,'output version information and exit')
+	if help{
+		println(fp.usage())
+		exit(0)
+	}
+	if version {
+		println('version')
+		exit(0)
+	}
+	lname := os.loginname()
+	if lname == '' {
+		error_exit('no login name')
+	}
+	println(lname)
+}
+fn old_main() {
 	usage := 'Usage: logname [OPTION]. [OPTION] can be --help, --version'
 	version := 'logname (V coreutils) 0.0.1'
 	args := os.args[1..]

--- a/logname/logname.v
+++ b/logname/logname.v
@@ -7,10 +7,10 @@ const (
 
 // A default error exit, when code is not important
 fn error_exit(errors ...string) {
-	error_exit_code(1,...errors)
+	error_exit_code(1, ...errors)
 }
 
-// Use only if error code is important (some semantic meaning to particular codes 
+// Use only if error code is important (some semantic meaning to particular codes
 fn error_exit_code(code int, errors ...string) {
 	for error in errors {
 		eprintln(error)
@@ -19,12 +19,13 @@ fn error_exit_code(code int, errors ...string) {
 }
 
 // Use if successful exit
-fn success_exit(messages...string) {
+fn success_exit(messages ...string) {
 	for message in messages {
 		println(message)
 	}
 	exit(0)
 }
+
 /*
 ** Standard function to perform basic flag parsing an help and version processing
 ** params: args - string array (should usually be os.args in main function)
@@ -32,21 +33,21 @@ fn success_exit(messages...string) {
 ** logic: Creates a parser with given arguments. Checks if --help or --version flag are present, and prints and exits if yes
 */
 
-fn flags_common(args []string, app_name string, free_args_min int, free_args_max int) (&flag.FlagParser, string){
+fn flags_common(args []string, app_name string, free_args_min int, free_args_max int) (&flag.FlagParser, string) {
 	// Flags
 	mut fp := flag.new_flag_parser(os.args)
 	fp.application(app_name)
-	fp.limit_free_args(free_args_min,free_args_max)
-	fp.version(version_str)	// Preferably take from common version constant, should be updated
-
+	fp.limit_free_args(free_args_min, free_args_max)
+	fp.version(version_str) // Preferably take from common version constant, should be updated
 	exec := fp.args[0]
+
 	// println(exec)
 
 	// --help and --version are standard flags for coreutils programs
-	help := fp.bool('help',0,false,'display this help and exit')
-	version := fp.bool('version',0,false,'output version information and exit')
-	
-	if help{
+	help := fp.bool('help', 0, false, 'display this help and exit')
+	version := fp.bool('version', 0, false, 'output version information and exit')
+
+	if help {
 		success_exit(fp.usage())
 	}
 	if version {
@@ -59,17 +60,18 @@ fn flags_common(args []string, app_name string, free_args_min int, free_args_max
 }
 
 // Use if no arguments are taken
-fn flags_common_no_args(args [] string, app_name string) (&flag.FlagParser,string) {
-	return flags_common(args,app_name,0,0)
+fn flags_common_no_args(args []string, app_name string) (&flag.FlagParser, string) {
+	return flags_common(args, app_name, 0, 0)
 }
 
-/* logname
+/*
+logname
 ** VinWare, 2021-07-05 05:00:00 UTC
 **
 ** Basic implementation of logname
 ** Does not specify ENV variables
 ** Follows POSIX (uses C getlogin)
-** 
+**
 ** Remaining issues:
 ** Standard error messages - Ongoing
 ** Standard way to take arguments - Solved by using flags module
@@ -77,11 +79,9 @@ fn flags_common_no_args(args [] string, app_name string) (&flag.FlagParser,strin
 
 fn main() {
 	// Exec is not needed
-	fp,_ := flags_common_no_args(os.args, 'logname')
+	fp, _ := flags_common_no_args(os.args, 'logname')
 
-	fp.finalize() or {
-		error_exit(err.str(),fp.usage())
-	}
+	fp.finalize() or { error_exit(err.str(), fp.usage()) }
 
 	// Main functionality
 
@@ -91,6 +91,6 @@ fn main() {
 		// C.getlogin failed
 		error_exit('no login name')
 	}
-	
+
 	success_exit(lname)
 }

--- a/logname/logname.v
+++ b/logname/logname.v
@@ -1,6 +1,68 @@
 import os
 import flag
 
+const (
+	version_str = 'V Coreutils 0.0.1'
+)
+
+// A default error exit, when code is not important
+fn error_exit(errors ...string) {
+	error_exit_code(1,...errors)
+}
+
+// Use only if error code is important (some semantic meaning to particular codes 
+fn error_exit_code(code int, errors ...string) {
+	for error in errors {
+		eprintln(error)
+	}
+	exit(code)
+}
+
+// Use if successful exit
+fn success_exit(messages...string) {
+	for message in messages {
+		println(message)
+	}
+	exit(0)
+}
+/*
+** Standard function to perform basic flag parsing an help and version processing
+** params: args - string array (should usually be os.args in main function)
+** returns: FlagParser object reference, exec name
+** logic: Creates a parser with given arguments. Checks if --help or --version flag are present, and prints and exits if yes
+*/
+
+fn flags_common(args []string, app_name string, free_args_min int, free_args_max int) (&flag.FlagParser, string){
+	// Flags
+	mut fp := flag.new_flag_parser(os.args)
+	fp.application(app_name)
+	fp.limit_free_args(free_args_min,free_args_max)
+	fp.version(version_str)	// Preferably take from common version constant, should be updated
+
+	exec := fp.args[0]
+	// println(exec)
+
+	// --help and --version are standard flags for coreutils programs
+	help := fp.bool('help',0,false,'display this help and exit')
+	version := fp.bool('version',0,false,'output version information and exit')
+	
+	if help{
+		success_exit(fp.usage())
+	}
+	if version {
+		success_exit(version_str) // Needs to be modified
+	}
+
+	fp.skip_executable()
+
+	return fp, exec
+}
+
+// Use if no arguments are taken
+fn flags_common_no_args(args [] string, app_name string) (&flag.FlagParser,string) {
+	return flags_common(args,app_name,0,0)
+}
+
 /* logname
 ** VinWare, 2021-07-05 05:00:00 UTC
 **
@@ -13,54 +75,13 @@ import flag
 ** Standard way to take arguments - Solved by using flags module
 */
 
-fn error_exit(errors ...string) {
-	for error in errors {
-		eprintln(error)
-	}
-	exit(1) 	
-}
-
-/*
-** Standard function to perform basic flag parsing an help and version processing
-** params: args - string array (should usually be os.args in main function)
-** returns: FlagParser object reference - may be used if other options are there
-** logic: Creates a parser with given arguments. Checks if --help or --version flag are present, and prints and exits if yes
-*/
-
-fn get_flags_help_version(args []string, app_name string, version_str string, free_args_min int, free_args_max int) &flag.FlagParser{
-	// Flags
-	mut fp := flag.new_flag_parser(os.args)
-	fp.application(app_name)
-	fp.limit_free_args(free_args_min,free_args_max)
-	fp.version(version_str)	// Preferably take from common version constant, should be updated
-	// exec := fp.args[0]
-	// println(exec)
-
-	// --help and --version are standard flags for coreutils programs
-	help := fp.bool('help',0,false,'display this help and exit')
-	version := fp.bool('version',0,false,'output version information and exit')
-	
-	if help{
-		println(fp.usage())
-		exit(0)
-	}
-	if version {
-		println('version')
-		exit(0)
-	}
-
-	fp.skip_executable()
+fn main() {
+	// Exec is not needed
+	fp,_ := flags_common_no_args(os.args, 'logname')
 
 	fp.finalize() or {
 		error_exit(err.str(),fp.usage())
 	}
-
-	return fp
-}
-
-fn main() {
-	// No options used here, so don't store returned parser
-	get_flags_help_version(os.args, 'logname', '0.0.1', 0, 0)
 
 	// Main functionality
 
@@ -70,5 +91,6 @@ fn main() {
 		// C.getlogin failed
 		error_exit('no login name')
 	}
-	println(lname)
+	
+	success_exit(lname)
 }

--- a/logname/logname.v
+++ b/logname/logname.v
@@ -1,6 +1,9 @@
 import os
 import flag
 
+/* The following block has been created in this file, but should be extracted to a common module for use by all utils
+*/
+
 const (
 	version_str = 'V Coreutils 0.0.1'
 )
@@ -10,7 +13,7 @@ fn error_exit(errors ...string) {
 	error_exit_code(1, ...errors)
 }
 
-// Use only if error code is important (some semantic meaning to particular codes
+// Use only if error code is important (some semantic meaning to particular codes)
 fn error_exit_code(code int, errors ...string) {
 	for error in errors {
 		eprintln(error)
@@ -38,7 +41,8 @@ fn flags_common(args []string, app_name string, free_args_min int, free_args_max
 	mut fp := flag.new_flag_parser(os.args)
 	fp.application(app_name)
 	fp.limit_free_args(free_args_min, free_args_max)
-	fp.version(version_str) // Preferably take from common version constant, should be updated
+	fp.version(version_str) // Preferably take from common version constant, should be updated regularly
+	fp.description('Tool to display login name')
 	exec := fp.args[0]
 
 	// println(exec)
@@ -63,6 +67,9 @@ fn flags_common(args []string, app_name string, free_args_min int, free_args_max
 fn flags_common_no_args(args []string, app_name string) (&flag.FlagParser, string) {
 	return flags_common(args, app_name, 0, 0)
 }
+
+/* End of common block
+*/
 
 /*
 logname

--- a/logname/logname.v
+++ b/logname/logname.v
@@ -1,5 +1,6 @@
 import os
 import flag
+
 /* logname
 ** VinWare, 2021-07-05 05:00:00 UTC
 **
@@ -30,7 +31,7 @@ fn main() {
 	// Flags
 	mut fp := flag.new_flag_parser(os.args)
 	fp.application('logname')
-	// fp.limit_free_args(0,0)
+	fp.limit_free_args_to_exactly(0)
 	help := fp.bool('help',0,false,'display this help and exit')
 	version := fp.bool('version',0,false,'output version information and exit')
 	if help{
@@ -40,6 +41,12 @@ fn main() {
 	if version {
 		println('version')
 		exit(0)
+	}
+	fp.skip_executable()
+	fp.finalize() or {
+		eprintln(err)
+		println(fp.usage())	
+		exit(1)
 	}
 	lname := os.loginname()
 	if lname == '' {


### PR DESCRIPTION
The code has been modularized, and some of the functions can be used by all the coreutils (further discussion needed on what to keep)

Main changes:

1. Added error_exit with error code, and success_exit for easy message printing and exiting
2. Moved initial flag processing and `--help` and `--version` logic into a different function

To use the functions as is in other utils:

1. Call the relevant flag function in the main function.
2. Perform further processing after the call
3. Call `fp.finalize()` as in the code in this file
4. Perform further processing after this