### PR TITLE
feat(cat): add cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Contributions are welcome!
 
 Please only contribute versions of the original utilities written in V.  Contributions written in other langauges will likely be rejected.
 
-## Completed (5/109)
+## Completed (7/109)
 
 | Done    | Cmd       | Descripton                                       |
 | :-----: |-----------|--------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please only contribute versions of the original utilities written in V.  Contrib
 |         | base64    | Transform data into printable data               |
 |         | basename  | Strip directory and suffix from a file name      |
 |         | basenc    | Transform data into printable data               |
-|         | cat       | Concatenate and write files                      |
+| &check; | cat       | Concatenate and write files                      |
 |         | chcon     | Change SELinux context of file                   |
 |         | chgrp     | Change group ownership                           |
 |         | chmod     | Change access permissions                        |

--- a/cat/cat.v
+++ b/cat/cat.v
@@ -17,10 +17,24 @@ struct Settings {
 	show_nonprinting bool
 	show_tabs        bool
 	unbuffered       bool
+	files            []string
 }
 
 fn cat(settings Settings) {
-	println(settings)
+	mut files := settings.files
+
+	// if there are no files, read from stdin
+	if files.len < 1 {
+		files = ['-']
+	}
+
+	for file in files {
+		if file == '-' {
+			content := os.get_raw_lines_joined()
+		} else {
+			content := os.read_file(file) or { panic('No Such File; $file') }
+		}
+	}
 }
 
 fn main() {
@@ -30,21 +44,21 @@ fn main() {
 	fp.description(app_description)
 	fp.skip_executable()
 
-	show_all             := fp.bool('show-all', `A`, false, 'equivalent to -vET')
-	number_nonblanks     := fp.bool('number-nonblank', `b`, false, "Number the lines, but don't count blank lines, override -n")
-	show_ends_and_v      := fp.bool('', `e`, false, 'equivalent to -vE')
-	mut show_ends        := fp.bool('show-ends', `E`, false, 'display $ at end of each line')
-	mut number_all       := fp.bool('number', `n`, false, 'Number the output lines, starting at 1.')
-	squeeze_blank        := fp.bool('sqeeze-blank', `s`, false, 'Squeeze multiple adjacent empty lines, causing the output to be single spaced')
-	mut show_tabs        := fp.bool('', `t`, false, 'Print tab characters as ‘^I’. Implies the -v option to display non-printing characters')
-	show_tabs_and_v      := fp.bool('', `T`, false, 'equivalent to -vT')
+	show_all := fp.bool('show-all', `A`, false, 'equivalent to -vET')
+	number_nonblanks := fp.bool('number-nonblank', `b`, false, "Number the lines, but don't count blank lines, override -n")
+	show_ends_and_v := fp.bool('', `e`, false, 'equivalent to -vE')
+	mut show_ends := fp.bool('show-ends', `E`, false, 'display $ at end of each line')
+	mut number_all := fp.bool('number', `n`, false, 'Number the output lines, starting at 1.')
+	squeeze_blank := fp.bool('sqeeze-blank', `s`, false, 'Squeeze multiple adjacent empty lines, causing the output to be single spaced')
+	mut show_tabs := fp.bool('', `t`, false, 'Print tab characters as ‘^I’. Implies the -v option to display non-printing characters')
+	show_tabs_and_v := fp.bool('', `T`, false, 'equivalent to -vT')
 	// unbuffered        := fp.bool('', `u`, false, 'The output is guaranteed to be unbuffered')
-	unbuffered           := fp.bool('', `u`, false, '(ignored)') // ignored in GNU cat!
+	unbuffered := fp.bool('', `u`, false, '(ignored)') // ignored in GNU cat!
 	mut show_nonprinting := fp.bool('show-nonprinting', `v`, false, 'use ^ and M- notation, except for LFD and TAB')
-	help                 := fp.bool('help', 0, false, 'display this help and exit')
-	version              := fp.bool('version', 0, false, 'output version information and exit')
+	help := fp.bool('help', 0, false, 'display this help and exit')
+	version := fp.bool('version', 0, false, 'output version information and exit')
 
-	additional_args := fp.finalize() or {
+	files := fp.finalize() or {
 		eprintln(err)
 		println(fp.usage())
 		exit(1)
@@ -60,11 +74,11 @@ fn main() {
 	}
 
 	// some flags override each other
-	show_ends        =        show_ends || show_ends_and_v || show_all
-	show_tabs        =        show_tabs || show_tabs_and_v || show_all
+	show_ends = show_ends || show_ends_and_v || show_all
+	show_tabs = show_tabs || show_tabs_and_v || show_all
 	show_nonprinting = show_nonprinting || show_ends_and_v || show_all || show_tabs_and_v
-	number_all       = number_all && !number_nonblanks
+	number_all = number_all && !number_nonblanks
 
 	cat(Settings{number_nonblanks, number_all, squeeze_blank, show_ends, show_nonprinting
-		|| show_ends_and_v, show_tabs, unbuffered})
+		|| show_ends_and_v, show_tabs, unbuffered, files})
 }

--- a/cat/cat.v
+++ b/cat/cat.v
@@ -40,20 +40,19 @@ fn cat(settings Settings) {
 	for fname in fnames {
 		mut file := os.File{}
 		if fname == '-' {
+			// handle stdin like Files
 			file = os.stdin()
 		} else {
 			file = os.open(fname) or {
-				eprintln('$fname couldn\'t be opened')
+				eprintln('$app_name: $fname: No such file or directory')
 				exit(1)
 			}
 		}
-		// mut content := os.get_lines()
-		//// formatted := format(content[0], settings) or { continue }
-		// println(formatted)
+
 		mut br := io.new_buffered_reader(io.BufferedReaderConfig{ reader: file })
 		// Instead of checking conditions for each line
-		// a different path can be taken for different options group
-		// for better 'performance'
+		// a different path can be taken for different
+		// options group for better 'performance'
 		format_cond := settings.show_ends || settings.show_tabs || settings.show_nonprinting
 		number_cond := settings.number_nonblanks || settings.number_all || settings.squeeze_blank
 
@@ -119,11 +118,12 @@ fn path_number_and_format(mut br io.BufferedReader, settings Settings) {
 // number_all       bool
 // squeeze_blank    bool
 fn number_lines(line string, last_line string, line_number int, settings Settings) ?(string, string, int) {
+	// number_all has overrides number_nonblanks.
 	if settings.squeeze_blank && line == '' && last_line == '' {
 		return error('skip line')
 	}
 	if settings.number_nonblanks && line != '' {
-		return ' $line_number\t$line', line, line_number + 1 // TODO DOCS!
+		return ' $line_number\t$line', line, line_number + 1
 	}
 	if settings.number_all {
 		return ' $line_number\t$line', line, line_number + 1

--- a/cat/cat.v
+++ b/cat/cat.v
@@ -1,0 +1,70 @@
+module main
+
+import flag
+import os
+
+const (
+	app_name        = 'cat'
+	app_version     = 'v0.0.1'
+	app_description = 'concatenate files and print on the standard output'
+)
+
+struct Settings {
+	number_nonblanks bool
+	number_all       bool
+	squeeze_blank    bool
+	show_ends        bool
+	show_nonprinting bool
+	show_tabs        bool
+	unbuffered       bool
+}
+
+fn cat(settings Settings) {
+	println(settings)
+}
+
+fn main() {
+	mut fp := flag.new_flag_parser(os.args)
+	fp.application(app_name)
+	fp.version(app_version)
+	fp.description(app_description)
+	fp.skip_executable()
+
+	show_all             := fp.bool('show-all', `A`, false, 'equivalent to -vET')
+	number_nonblanks     := fp.bool('number-nonblank', `b`, false, "Number the lines, but don't count blank lines, override -n")
+	show_ends_and_v      := fp.bool('', `e`, false, 'equivalent to -vE')
+	mut show_ends        := fp.bool('show-ends', `E`, false, 'display $ at end of each line')
+	mut number_all       := fp.bool('number', `n`, false, 'Number the output lines, starting at 1.')
+	squeeze_blank        := fp.bool('sqeeze-blank', `s`, false, 'Squeeze multiple adjacent empty lines, causing the output to be single spaced')
+	mut show_tabs        := fp.bool('', `t`, false, 'Print tab characters as ‘^I’. Implies the -v option to display non-printing characters')
+	show_tabs_and_v      := fp.bool('', `T`, false, 'equivalent to -vT')
+	// unbuffered        := fp.bool('', `u`, false, 'The output is guaranteed to be unbuffered')
+	unbuffered           := fp.bool('', `u`, false, '(ignored)') // ignored in GNU cat!
+	mut show_nonprinting := fp.bool('show-nonprinting', `v`, false, 'use ^ and M- notation, except for LFD and TAB')
+	help                 := fp.bool('help', 0, false, 'display this help and exit')
+	version              := fp.bool('version', 0, false, 'output version information and exit')
+
+	additional_args := fp.finalize() or {
+		eprintln(err)
+		println(fp.usage())
+		exit(1)
+	}
+
+	if help {
+		println(fp.usage())
+		exit(0)
+	}
+	if version {
+		println('$app_name $app_version')
+		exit(0)
+	}
+
+	// some flags override each other
+	show_ends        =        show_ends || show_ends_and_v || show_all
+	show_tabs        =        show_tabs || show_tabs_and_v || show_all
+	show_nonprinting = show_nonprinting || show_ends_and_v || show_all || show_tabs_and_v
+	number_all       = number_all && !number_nonblanks
+
+	cat(Settings{number_nonblanks, number_all, squeeze_blank, show_ends, show_nonprinting
+		|| show_ends_and_v, show_tabs, unbuffered})
+}

--- a/cat/cat.v
+++ b/cat/cat.v
@@ -10,7 +10,7 @@ const (
 )
 
 struct Settings {
-	number_nonblanks bool
+	number_nonblanks bool // both number_nonblank, and number_all can never be true together
 	number_all       bool
 	squeeze_blank    bool
 	show_ends        bool
@@ -30,11 +30,42 @@ fn cat(settings Settings) {
 
 	for file in files {
 		if file == '-' {
-			content := os.get_raw_lines_joined()
+			// mut content := os.get_lines()
+			//// formatted := format(content[0], settings) or { continue }
+			// println(formatted)
 		} else {
-			content := os.read_file(file) or { panic('No Such File; $file') }
+			mut lines := os.read_lines(file) or { panic('$file could not be opened') }
+			// TODO: make unbuffered
+			for line in lines {
+				formatted := format(line, settings)
+				println(formatted)
+			}
 		}
 	}
+}
+
+// format , formats a line according to the settings,
+// returns error on empty lines
+fn format(content string, settings Settings) string {
+	mut line := content
+
+	// if settings.squeeze_blank && line == '' {
+	//}
+	// if settings.number_nonblanks && line != '' {
+	//	line = ' $line_number\t$line'
+	//}
+	// if settings.number_all {
+	//	line = ' $line_number\t$line'
+	//}
+	if settings.show_ends {
+		line += '$'
+	}
+	if settings.show_nonprinting {
+	}
+	if settings.show_tabs {
+		line = line.replace('\t', '^I')
+	}
+	return line
 }
 
 fn main() {


### PR DESCRIPTION
# Implemented
```
  -A, --show-all            equivalent to -vET
  -b, --number-nonblank     Number the lines, but don't count blank lines, override -n
  -e                        equivalent to -vE
  -E, --show-ends           display $ at end of each line
  -n, --number              Number the output lines, starting at 1.
  -s, --sqeeze-blank        Squeeze multiple adjacent empty lines, causing the output to be single spaced
  -t                        Print tab characters as ‘^I’. Implies the -v option to display non-printing characters
  -T                        equivalent to -vT
  -u                        (ignored)
  --help                    display this help and exit
  --version                 output version information and exit

```
# not yet

```
  -v, --show-nonprinting    use ^ and M- notation, except for LFD and TAB
```

# Known Issues

stdin  doesn't handle 'line by line'
