### PR TITLE
Seq

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Contributions are welcome!
 Please only contribute versions of the original utilities written in V.
 Contributions written in other langauges will likely be rejected.
 
-## Completed (10/109)
+## Completed (11/109)
 
 | Done    | Cmd       | Descripton                                       |
 | :-----: |-----------|--------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Contributions written in other langauges will likely be rejected.
 |         | rm        | Remove files or directories                      |
 |         | rmdir     | Remove empty directories                         |
 |         | runcon    | Run a command in specified SELinux context       |
-|         | seq       | Print numeric sequences                          |
+| &check; | seq       | Print numeric sequences                          |
 |         | sha1sum   | Print or check SHA-1 digests                     |
 |         | sha224sum | Print or check SHA-2 224 bit digests             |
 |         | sha256sum | Print or check SHA-2 256 bit digests             |

--- a/src/seq/seq.v
+++ b/src/seq/seq.v
@@ -2,6 +2,7 @@ module main
 
 import flag
 import os
+import strconv
 
 const (
 	app_name        = 'seq'
@@ -40,12 +41,12 @@ fn seq(set Settings) {
 	inc := set.increment.f64()
 
 	/// gets format string for printf
-	fstr := get_fstr(set).str
+	fstr := get_fstr(set)
 
 	mut i := set.first.f64()
 	for i < last {
 		i += inc
-		C.printf(fstr, i)
+		print(strconv.v_sprintf(fstr, i))
 	}
 }
 

--- a/src/seq/seq.v
+++ b/src/seq/seq.v
@@ -34,9 +34,9 @@ fn seq(set Settings) {
 	fstr := get_fstr(set).str
 
 	mut i := set.first.f64()
-	for i <= last {
-		C.printf(fstr, i)
+	for i < last {
 		i += inc
+		C.printf(fstr, i)
 	}
 }
 

--- a/src/seq/seq.v
+++ b/src/seq/seq.v
@@ -24,6 +24,14 @@ struct Settings {
 
 fn main() {
 	settings := args() ?
+
+	// sanitize settings
+	check_settings(settings) or {
+		eprintln(err)
+		eprintln("Try '$app_name --help' for more information.")
+		exit(1)
+	}
+
 	seq(settings)
 }
 
@@ -90,6 +98,13 @@ fn num_of_decimals(s string) int {
 [inline]
 fn largest(x int, y int) int {
 	return if x > y { x } else { y }
+}
+
+[inline]
+fn check_settings(set Settings) ? {
+	if set.increment.f64() == 0 {
+		return error("$app_name: invalid zero increment value '0'")
+	}
 }
 
 ///===================================================================///

--- a/src/seq/seq.v
+++ b/src/seq/seq.v
@@ -2,7 +2,6 @@ module main
 
 import flag
 import os
-import math
 
 const (
 	app_name        = 'seq'
@@ -14,7 +13,7 @@ struct Settings {
 	format      string
 	separator   string
 	equal_width bool
-	first       string // can be a decimal
+	first       string
 	increment   string
 	last        string
 }
@@ -27,19 +26,16 @@ fn main() {
 	seq(args())
 }
 
-//
 fn seq(set Settings) {
 	last := set.last.f64()
 	inc := set.increment.f64()
 
 	/// gets format string for printf
-	// fstr := get_fstr(set)
-	fstr := '${get_fstr(set)}'
-	println(fstr)
+	fstr := get_fstr(set).str
 
 	mut i := set.first.f64()
 	for i <= last {
-		C.printf(fstr.str, i)
+		C.printf(fstr, i)
 		i += inc
 	}
 }
@@ -72,6 +68,12 @@ fn get_fstr(set Settings) string {
 		flen := set.first.split('.')[0].len
 		llen := set.last.split('.')[0].len
 		padding = largest(flen, llen)
+
+		// decimals are counted in padding
+		// 0.999 padded to 6 => 00.999
+		if decimals > 0 {
+			padding += decimals + 1 // +1 since '.' is counted too
+		}
 	}
 
 	return '%0${padding}.$decimals$ctype$set.separator'

--- a/src/seq/seq.v
+++ b/src/seq/seq.v
@@ -1,0 +1,110 @@
+module main
+
+import flag
+import os
+
+const (
+	app_name        = 'seq'
+	app_version     = 'v0.0.1'
+	app_description = 'print a sequence of numbers'
+)
+
+struct Settings {
+	format      string
+	separator   string
+	equal_width bool
+	first       f64 // can be a decimal
+	increment   f64
+	last        f64
+}
+
+///===================================================================///
+///                       Main Logic                                  ///
+///===================================================================///
+
+fn main() {
+	seq(args())
+}
+
+fn seq(s Settings) {
+	sep := s.separator.bytes()
+	last := s.last
+	inc := s.increment
+
+	mut i := s.first
+	mut stdout := os.stdout()
+	for i <= last {
+		stdout.write(i.str().bytes()) or {}
+		stdout.write(sep) or {}
+		i += inc
+	}
+}
+
+///===================================================================///
+///                       Helper Functions                            ///
+///===================================================================///
+
+///===================================================================///
+///                                Args                               ///
+///===================================================================///
+
+fn args() Settings {
+	mut fp := flag.new_flag_parser(os.args)
+	fp.application(app_name)
+	fp.version(app_version)
+	fp.description(app_description)
+	fp.skip_executable()
+
+	// need to change this
+	format := fp.string('format', `f`, '%i', 'use printf style floating-point FORMAT')
+	separator := fp.string('separator', `s`, '\n', 'use STRING to separate numbers (default: \n)')
+	equal_width := fp.bool('equal-width', `w`, false, 'equalize width by padding with leading zeroes')
+
+	help := fp.bool('help', 0, false, 'display this help and exit')
+	version := fp.bool('version', 0, false, 'output version information and exit')
+
+	// extra arguments -a -b -c arg1 arg2 arg3
+	// arg1..3 will be taken
+	// flags used that are not specified will panic
+	fnames := fp.finalize() or {
+		eprintln(err)
+		println(fp.usage())
+		exit(1)
+	}
+
+	if help {
+		println(fp.usage())
+		exit(0)
+	}
+	if version {
+		println('$app_name $app_version')
+		exit(0)
+	}
+
+	match fnames.len {
+		0 {
+			eprintln('$app_name: missinge operand')
+			eprintln("Try '$app_name --help' for more information.")
+			exit(1)
+		}
+		1 {
+			// _, _, last=fnames[0]
+			return Settings{format, separator, equal_width, 0, 1, fnames[0].f64()}
+		}
+		2 {
+			//  first=fnames[0], _, last=fnames[1],
+			return Settings{format, separator, equal_width, fnames[0].f64(), 1, fnames[1].f64()}
+		}
+		3 {
+			//  first=fnames[0], increment[1], last=fnames[2],
+			return Settings{format, separator, equal_width, fnames[0].f64(), fnames[1].f64(), fnames[2].f64()}
+		}
+		else {
+			eprintln("$app_name: extra operand '${fnames[3]}'")
+			eprintln("Try '$app_name --help' for more information.")
+			exit(1)
+		}
+	}
+	// making compiler happy, should never happen
+	return Settings{format, separator, equal_width, 0, 0, 0}
+}

--- a/src/seq/seq.v
+++ b/src/seq/seq.v
@@ -23,7 +23,8 @@ struct Settings {
 ///===================================================================///
 
 fn main() {
-	seq(args())
+	settings := args() ?
+	seq(settings)
 }
 
 fn seq(set Settings) {
@@ -95,7 +96,7 @@ fn largest(x int, y int) int {
 ///                                Args                               ///
 ///===================================================================///
 
-fn args() Settings {
+fn args() ?Settings {
 	mut fp := flag.new_flag_parser(os.args)
 	fp.application(app_name)
 	fp.version(app_version)
@@ -107,9 +108,6 @@ fn args() Settings {
 	separator := fp.string('separator', `s`, '\n', 'use STRING to separate numbers (default: \n)')
 	equal_width := fp.bool('equal-width', `w`, false, 'equalize width by padding with leading zeroes')
 
-	help := fp.bool('help', 0, false, 'display this help and exit')
-	version := fp.bool('version', 0, false, 'output version information and exit')
-
 	// extra arguments -a -b -c arg1 arg2 arg3
 	// arg1..3 will be taken
 	// flags used that are not specified will panic
@@ -119,18 +117,9 @@ fn args() Settings {
 		exit(1)
 	}
 
-	if help {
-		println(fp.usage())
-		exit(0)
-	}
-	if version {
-		println('$app_name $app_version')
-		exit(0)
-	}
-
 	match fnames.len {
 		0 {
-			eprintln('$app_name: missinge operand')
+			eprintln('$app_name: missing operand')
 			eprintln("Try '$app_name --help' for more information.")
 			exit(1)
 		}
@@ -152,6 +141,5 @@ fn args() Settings {
 			exit(1)
 		}
 	}
-	// making compiler happy, should never happen
-	return Settings{format, separator, equal_width, '0', '0', '0'}
+	return error('invalid parameters')
 }


### PR DESCRIPTION
impl seq

known issues

```sh
seq 1.11.1 #works
seq a # works
gnuSeq 1.11.1 # errors: 'invalid floating point argument' 

```
reason: `.f64()` doesn't return an optional

closes #8 