### PR TITLE
implement `base64`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Contributions are welcome!
 Please only contribute versions of the original utilities written in V.
 Contributions written in other langauges will likely be rejected.
 
-## Completed (13/109)
+## Completed (14/109)
 
 | Done    | Cmd       | Descripton                                       |
 | :-----: |-----------|--------------------------------------------------|
@@ -37,7 +37,7 @@ Contributions written in other langauges will likely be rejected.
 | &check; | arch      | Print machine hardware name                      |
 |         | b2sum     | Print or check BLAKE2 digests                    |
 |         | base32    | Transform data into printable data               |
-|         | base64    | Transform data into printable data               |
+| &check; | base64    | Transform data into printable data               |
 |         | basename  | Strip directory and suffix from a file name      |
 |         | basenc    | Transform data into printable data               |
 | &check; | cat       | Concatenate and write files                      |

--- a/src/base64/base64.v
+++ b/src/base64/base64.v
@@ -1,5 +1,6 @@
 import os
 import flag
+import common
 import encoding.base64
 
 const (
@@ -153,14 +154,17 @@ fn decode_and_print(mut file os.File) {
 fn main() {
 	mut fp := flag.new_flag_parser(os.args)
 	fp.application(application_name)
-	fp.version('(V coreutils 0.0.1)')
+	fp.version(common.coreutils_version())
+	fp.footer(common.coreutils_footer())
 	fp.skip_executable()
 	fp.usage_example('[OPTION]... [FILE]')
 	fp.description('Base64 encode or decode FILE, or standard input, to standard output.')
 	fp.description('If no FILE is specified on the command line or FILE is -, read them from standard input.')
 
 	decode_opt := fp.bool('decode', `d`, false, 'decode data')
-	wraping_opt := fp.int('wrap=', `w`, 76, 'wrap encoded lines after COLS character (default 76).\n\t\t\t\tUse 0 to disable line wrapping')
+	wraping_opt := fp.int('wrap=', `w`, 76,
+		'wrap encoded lines after COLS character (default 76).' +
+		'\n\t\t\t\t\t\t\t\t\tUse 0 to disable line wrapping.')
 	args := fp.finalize() or {
 		eprintln(err)
 		exit(1)

--- a/src/base64/base64.v
+++ b/src/base64/base64.v
@@ -1,0 +1,133 @@
+import os
+import flag
+import encoding.base64
+
+const (
+	application_name   = 'base64'
+
+	// multiple of 3 so we can encode the data in chunks and concatenate
+	chunk_size         = 15 * 1024
+
+	// 4/3 of chunksize
+	buffer_size_encode = 4 * (15 / 3) * 1024
+)
+
+fn get_file(args []string) os.File {
+	if args.len == 0 || args[0] == '-' {
+		return os.stdin()
+	} else {
+		file_path := args[0]
+		return os.open(file_path) or {
+			eprintln('$application_name: $file_path: No such file or directory')
+			exit(1)
+		}
+	}
+}
+
+fn encode_and_print(mut file os.File, wrap int) {
+	mut std_out := os.stdout()
+	defer {
+		file.close()
+		std_out.close()
+	}
+	mut in_buffer := []byte{len: chunk_size}
+	mut out_buffer := []byte{len: buffer_size_encode}
+
+	// read the file in chunks for constant memory usage.
+	mut pos := u64(0)
+	for {
+		r_bytes := file.read_bytes_into(pos, mut in_buffer) or {
+			match err {
+				none {
+					0
+				}
+				else {
+					-1
+				}
+			}
+		}
+
+		match r_bytes {
+			0 {
+				break
+			}
+			-1 {
+				eprintln('$application_name: Cannot read file')
+				exit(1)
+			}
+			else {
+				pos += u64(r_bytes)
+			}
+		}
+
+		e_bytes := base64.encode_in_buffer(in_buffer[..r_bytes], out_buffer.data)
+
+		// print newlines after specified wrap.
+		if wrap != 0 {
+			mut p_bytes := 0
+			for ((e_bytes - p_bytes) >= wrap) {
+				write_to := p_bytes + wrap
+				std_out.write(out_buffer[p_bytes..write_to]) or {
+					eprintln(err)
+					exit(1)
+				}
+				// flushing is needed here, as otherwise all writes are cached.
+				std_out.flush()
+				print('\n')
+				p_bytes += wrap
+			}
+			// print rest of the data.
+			l_bytes := std_out.write(out_buffer[p_bytes..e_bytes]) or {
+				eprintln(err)
+				exit(1)
+			}
+			std_out.flush()
+			if l_bytes != 0 {
+				print('\n')
+			}
+		} else {
+			std_out.write(out_buffer[..e_bytes]) or {
+				eprintln(err)
+				exit(1)
+			}
+		}
+	}
+}
+
+fn decode_and_print(mut file os.File) {
+}
+
+fn main() {
+	mut fp := flag.new_flag_parser(os.args)
+	fp.application(application_name)
+	fp.version('(V coreutils 0.0.1)')
+	fp.skip_executable()
+	fp.usage_example('[OPTION]... [FILE]')
+	fp.description('Base64 encode or decode FILE, or standard input, to standard output.')
+	fp.description('If no FILE is specified on the command line or FILE is -, read them from standard input.')
+
+	decode_opt := fp.bool('decode', `d`, false, 'decode data')
+	// ignore_garbage_opt := fp.bool('ignore-garbage', 0, false, 'when decoding, ignore non-alphabet characters')
+	wraping_opt := fp.int('wrap=', `w`, 76, 'wrap encoded lines after COLS character (default 76).\n\t\t\t\tUse 0 to disable line wrapping')
+	args := fp.finalize() or {
+		eprintln(err)
+		exit(1)
+	}
+	if args.len > 1 {
+		extra_arg := args[1]
+		eprintln('$application_name: extra operand `$extra_arg`')
+		eprintln("Try 'base64 --help' for more information.")
+		exit(1)
+	}
+	if wraping_opt < 0 {
+		eprintln('$application_name: invalid wrap size: \'$wraping_opt\'')
+		exit(1)
+	}
+
+	mut file := get_file(args)
+
+	match decode_opt {
+		true { decode_and_print(mut file) }
+		else { encode_and_print(mut file, wraping_opt) }
+	}
+}

--- a/src/base64/base64.v
+++ b/src/base64/base64.v
@@ -142,8 +142,8 @@ fn decode_and_print(mut file os.File) {
 		}
 		unsafe {
 			base64_string := tos(in_buffer.data, n_bytes)
-			encoded_bytes := base64.decode_in_buffer(base64_string, out_buffer.data)
-			std_out.write(out_buffer[..encoded_bytes]) or {
+			decoded_bytes := base64.decode_in_buffer(base64_string, out_buffer.data)
+			std_out.write(out_buffer[..decoded_bytes]) or {
 				eprintln(err)
 				exit(1)
 			}

--- a/src/base64/base64_test.v
+++ b/src/base64/base64_test.v
@@ -1,0 +1,62 @@
+import os
+import common.testing
+
+const the_executable = testing.prepare_executable('base64')
+
+const cmd = testing.new_paired_command('base64', the_executable)
+
+fn test_help_and_version() ? {
+	cmd.ensure_help_and_version_options_work() ?
+}
+
+fn test_abcd() {
+	res := os.execute('$the_executable abcd')
+	assert res.exit_code == 1
+	assert res.output.trim_space() == 'base64: abcd: No such file or directory'
+}
+
+fn expected_result_no_wrap(input string, output []string) {
+	res := os.execute('$the_executable $input')
+	assert res.exit_code == 0
+	assert res.output.split_into_lines() == output
+	testing.same_results('base64 -w 0 $input', '$the_executable -w 0 $input')
+}
+
+fn expected_result_default_wrap(input string, output []string) {
+	res := os.execute('$the_executable $input')
+	assert res.exit_code == 0
+	assert res.output.split_into_lines() == output
+	testing.same_results('base64 $input', '$the_executable $input')
+}
+
+fn expected_result_1_char_wrap(input string, output []string) {
+	res := os.execute('$the_executable $input')
+	assert res.exit_code == 0
+	assert res.output.split_into_lines() == output
+	testing.same_results('base64 -w 1 $input', '$the_executable -w 1 $input')
+}
+
+fn expected_result_decode(input string, output []string) {
+	res := os.execute('$the_executable $input')
+	assert res.exit_code == 0
+	assert res.output.split_into_lines() == output
+	testing.same_results('base64 $input', '$the_executable $input')
+}
+
+fn test_expected() ?{
+	mut f := os.open_file('textfile', 'w') ?
+	f.write_string('Hello World!\nHow are you?') ?
+	f.close()
+
+	mut g := os.open_file('base64file', 'w') ?
+	g.write_string('ViBjb3JldXRpbHMgaXMgYXdlc29tZSEK') ?
+	g.close()
+
+	expected_result_no_wrap('textfile', ['SGVsbG8gV29ybGQhCkhvdyBhcmUgeW91Pw=='])
+	expected_result_default_wrap('textfile', ['SGVsbG8gV29ybGQhCkhvdyBhcmUgeW91Pw=='])
+	expected_result_1_char_wrap('textfile', ['SGVsbG8gV29ybGQhCkhvdyBhcmUgeW91Pw=='])
+	expected_result_decode('-d base64file', ['V coreutils is awesome!'])
+
+	os.rm('textfile') ?
+	os.rm('base64file') ?
+}

--- a/src/base64/base64_test.v
+++ b/src/base64/base64_test.v
@@ -43,7 +43,7 @@ fn expected_result_decode(input string, output []string) {
 	testing.same_results('base64 $input', '$the_executable $input')
 }
 
-fn test_expected() ?{
+fn test_expected() ? {
 	mut f := os.open_file('textfile', 'w') ?
 	f.write_string('Hello World!\nHow are you?') ?
 	f.close()


### PR DESCRIPTION
closes #29

I wrote several comments in the code explaining my thoughts and also explaining why certain checks are needed to match GNU coreutils output.

Only flag that is not implemented is `-i, --ignore-garbage  when decoding, ignore non-alphabet characters ` as the standard libraries base64 module does not support ignoring garbage characters.