### PR TITLE
base64: run tests correctly (and manually flush less often)

### DIFF
--- a/src/base64/base64.v
+++ b/src/base64/base64.v
@@ -73,6 +73,7 @@ fn encode_and_print(mut file os.File, wrap int) {
 
 		// print newlines after specified wrap.
 		if wrap != 0 {
+			newline := []byte{len: 1, init: `\n`}
 			mut printed_bytes := 0
 			for ((encoded_bytes - printed_bytes) >= wrap) {
 				// Don't write further than wrap.
@@ -81,9 +82,10 @@ fn encode_and_print(mut file os.File, wrap int) {
 					eprintln(err)
 					exit(1)
 				}
-				// flushing is needed here, as otherwise all writes are cached.
-				std_out.flush()
-				print('\n')
+				std_out.write(newline) or {
+					eprintln(err)
+					exit(1)
+				}
 				printed_bytes += wrap - last_column
 				// reset last_column as we have filled up the row.
 				last_column = 0
@@ -93,6 +95,8 @@ fn encode_and_print(mut file os.File, wrap int) {
 				eprintln(err)
 				exit(1)
 			}
+			// flush here, as otherwise the very final newline is printed
+			// before the data that's actually left.
 			std_out.flush()
 			// remember column for the next chunk.
 			last_column = encoded_bytes - printed_bytes

--- a/src/base64/base64_test.v
+++ b/src/base64/base64_test.v
@@ -15,48 +15,27 @@ fn test_abcd() {
 	assert res.output.trim_space() == 'base64: abcd: No such file or directory'
 }
 
-fn expected_result_no_wrap(input string, output []string) {
+fn expected_result(input string, output string) {
 	res := os.execute('$the_executable $input')
 	assert res.exit_code == 0
-	assert res.output.split_into_lines() == output
-	testing.same_results('base64 -w 0 $input', '$the_executable -w 0 $input')
-}
-
-fn expected_result_default_wrap(input string, output []string) {
-	res := os.execute('$the_executable $input')
-	assert res.exit_code == 0
-	assert res.output.split_into_lines() == output
+	assert res.output == output
 	testing.same_results('base64 $input', '$the_executable $input')
 }
 
-fn expected_result_1_char_wrap(input string, output []string) {
-	res := os.execute('$the_executable $input')
-	assert res.exit_code == 0
-	assert res.output.split_into_lines() == output
-	testing.same_results('base64 -w 1 $input', '$the_executable -w 1 $input')
-}
-
-fn expected_result_decode(input string, output []string) {
-	res := os.execute('$the_executable $input')
-	assert res.exit_code == 0
-	assert res.output.split_into_lines() == output
-	testing.same_results('base64 $input', '$the_executable $input')
-}
-
-fn test_expected() ? {
-	mut f := os.open_file('textfile', 'w') ?
-	f.write_string('Hello World!\nHow are you?') ?
+fn test_expected() {
+	mut f := os.open_file('textfile', 'w') or { exit(1) }
+	f.write_string('Hello World!\nHow are you?') or {}
 	f.close()
 
-	mut g := os.open_file('base64file', 'w') ?
-	g.write_string('ViBjb3JldXRpbHMgaXMgYXdlc29tZSEK') ?
+	mut g := os.open_file('base64file', 'w') or { exit(1) }
+	g.write_string('ViBjb3JldXRpbHMgaXMgYXdlc29tZSEK') or {}
 	g.close()
 
-	expected_result_no_wrap('textfile', ['SGVsbG8gV29ybGQhCkhvdyBhcmUgeW91Pw=='])
-	expected_result_default_wrap('textfile', ['SGVsbG8gV29ybGQhCkhvdyBhcmUgeW91Pw=='])
-	expected_result_1_char_wrap('textfile', ['SGVsbG8gV29ybGQhCkhvdyBhcmUgeW91Pw=='])
-	expected_result_decode('-d base64file', ['V coreutils is awesome!'])
+	expected_result('textfile', 'SGVsbG8gV29ybGQhCkhvdyBhcmUgeW91Pw==\n')
+	expected_result('-w 0 textfile', 'SGVsbG8gV29ybGQhCkhvdyBhcmUgeW91Pw==')
+	expected_result('-w 1 textfile', 'S\nG\nV\ns\nb\nG\n8\ng\nV\n2\n9\ny\nb\nG\nQ\nh\nC\nk\nh\nv\nd\ny\nB\nh\nc\nm\nU\ng\ne\nW\n9\n1\nP\nw\n=\n=\n')
+	expected_result('-d base64file', 'V coreutils is awesome!\n')
 
-	os.rm('textfile') ?
-	os.rm('base64file') ?
+	os.rm('textfile') or {}
+	os.rm('base64file') or {}
 }


### PR DESCRIPTION
This was my oversight...

You can't add flags in the functions themselves, but have to pass them in the input.
Without the tests failing at first, I did not even notice my (obvious) mistake. This is corrected now and tests are testing properly now.

Additionally I removed the manual flushing of stdout, as it should now flush automatically with each newline print.

(I further tried to speed up this utility by disabling flushing on newlines, but it did not show a noticeable speed-up.)