### PR TITLE
test: fix for locale consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ fmt:
 	v fmt -w .
 
 test:
-	v test .	
+	LANG=C v test .	
 
 testfmt:
 	v fmt -verify .

--- a/src/sleep/sleep.v
+++ b/src/sleep/sleep.v
@@ -32,7 +32,7 @@ fn apply_unit(n f64, unit string) ?f64 {
 }
 
 fn invalid_time_interval(n f64, unit string) string {
-	return '$cmd_ns: invalid time interval ‘$n$unit’'
+	return "$cmd_ns: invalid time interval '$n$unit'"
 }
 
 fn main() {


### PR DESCRIPTION
Because local language setting in development environment may not be English, so I add environment variable `LANG=C` to makefile.