### PR TITLE
common: add `is_utf8`

### DIFF
--- a/common/common.c.v
+++ b/common/common.c.v
@@ -1,0 +1,14 @@
+module common
+
+#include <locale.h>
+
+fn C.setlocale(category int, locale &char) &char
+
+fn init() {
+	C.setlocale(C.LC_ALL, ''.str)
+}
+
+pub fn is_utf8() bool {
+	locale := unsafe { C.setlocale(C.LC_CTYPE, &char(0)).vstring().to_lower() }
+	return locale.contains_any_substr(['utf8', 'utf-8'])
+}

--- a/common/common.c.v
+++ b/common/common.c.v
@@ -8,6 +8,7 @@ fn init() {
 	C.setlocale(C.LC_ALL, ''.str)
 }
 
+// is_utf8 returns whether the locale supports UTF-8 or not
 pub fn is_utf8() bool {
 	locale := unsafe { C.setlocale(C.LC_CTYPE, &char(0)).vstring().to_lower() }
 	return locale.contains_any_substr(['utf8', 'utf-8'])

--- a/src/expr/expr.v
+++ b/src/expr/expr.v
@@ -4,6 +4,7 @@ import os
 import strings
 import strconv
 import regex
+import common
 
 const appname = 'expr'
 
@@ -18,7 +19,7 @@ Options:
   --help                   display this help and exit
   --version                output version information and exit'
 
-const locale = os.getenv('LANG').ends_with('UTF-8') || os.getenv('LANG').ends_with('utf8')
+const locale = common.is_utf8()
 
 type Value = i64 | string
 


### PR DESCRIPTION
This method returns the locale is UTF-8 or not, so that we can easily create commands whose behavior depends on multibyte support.