### PR TITLE
yes: speed up yes by reusing buffer

### DIFF
--- a/src/yes/yes.v
+++ b/src/yes/yes.v
@@ -5,6 +5,7 @@ import os
 
 const (
 	app_name = 'yes'
+	buf_size = 8192
 )
 
 fn yes() {
@@ -23,9 +24,24 @@ fn yes() {
 	if additional_args.len > 0 {
 		str = additional_args.join(' ')
 	}
+	str += '\n'
+	expletive := voidptr(&(str.bytes())[0])
 
-	for {
-		println(str)
+	mut yes_buf := unsafe { malloc(buf_size) }
+	mut buf_used := 0
+
+	for buf_used + str.len <= buf_size {
+		unsafe {
+			vmemcpy(yes_buf + buf_used, expletive, str.len)
+		}
+		buf_used += str.len
+	}
+
+	mut out := os.stdout()
+	unsafe {
+		for {
+			out.write_ptr(yes_buf, buf_used)
+		}
 	}
 }
 

--- a/src/yes/yes.v
+++ b/src/yes/yes.v
@@ -19,22 +19,21 @@ fn yes() {
 		exit(1)
 	}
 
-	mut str := 'y'
+	mut expletive := 'y'
 
 	if additional_args.len > 0 {
-		str = additional_args.join(' ')
+		expletive = additional_args.join(' ')
 	}
-	str += '\n'
-	expletive := voidptr(&(str.bytes())[0])
+	expletive += '\n'
 
 	mut yes_buf := unsafe { malloc(buf_size) }
 	mut buf_used := 0
 
-	for buf_used + str.len <= buf_size {
+	for buf_used + expletive.len <= buf_size {
 		unsafe {
-			vmemcpy(yes_buf + buf_used, expletive, str.len)
+			vmemcpy(yes_buf + buf_used, expletive.str, expletive.len)
 		}
-		buf_used += str.len
+		buf_used += expletive.len
 	}
 
 	mut out := os.stdout()


### PR DESCRIPTION
This addresses the speed of yes  as described in #70 and the linked articles.

This uses a lot of unsafe and C features under the hood, so I am unsure if this satisfies the idea of portability of this V coreutils implementation.

The new speed averages around `3.5GB/s`.