### PR TITLE
hostid: Initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Contributions are welcome!
 Please only contribute versions of the original utilities written in V.
 Contributions written in other languages will likely be rejected.
 
-## Completed (37/109)
+## Completed (38/109)
 
 |  Done   | Cmd       | Descripton                                       |
 | :-----: | --------- | ------------------------------------------------ |
@@ -74,7 +74,7 @@ Contributions written in other languages will likely be rejected.
 |         | fold      | Wrap input lines to fit in specified width       |
 |         | groups    | Print group names a user is in                   |
 |         | head      | Output the first part of files                   |
-|         | hostid    | Print numeric host identifier                    |
+| &check; | hostid    | Print numeric host identifier                    |
 | &check; | hostname  | Print or set system name                         |
 |         | id        | Print user identity                              |
 |         | install   | Copy files and set attributes                    |

--- a/src/hostid/README.md
+++ b/src/hostid/README.md
@@ -1,0 +1,5 @@
+# hostid
+Implementation of hostid as in GNU Coreutils in V
+
+Author:
+B "SheatNoisette" Malhomme

--- a/src/hostid/gethostid_default.c.v
+++ b/src/hostid/gethostid_default.c.v
@@ -1,0 +1,8 @@
+
+/*
+** Get hostid on unsupported platforms
+*/
+fn hd_get_hostid() u32 {
+	eprintln("Unsupported platform")
+	return 0
+}

--- a/src/hostid/gethostid_default.c.v
+++ b/src/hostid/gethostid_default.c.v
@@ -1,8 +1,7 @@
-
 /*
 ** Get hostid on unsupported platforms
 */
 fn hd_get_hostid() u32 {
-	eprintln("Unsupported platform")
+	eprintln('Unsupported platform')
 	return 0
 }

--- a/src/hostid/gethostid_nix.c.v
+++ b/src/hostid/gethostid_nix.c.v
@@ -1,4 +1,3 @@
-
 #include <unistd.h>
 
 fn C.gethostid() int

--- a/src/hostid/gethostid_nix.c.v
+++ b/src/hostid/gethostid_nix.c.v
@@ -1,0 +1,11 @@
+
+#include <unistd.h>
+
+fn C.gethostid() int
+
+/*
+** Get hostid from GNU libc
+*/
+fn hd_get_hostid() u32 {
+	return u32(C.gethostid())
+}

--- a/src/hostid/hostid.v
+++ b/src/hostid/hostid.v
@@ -21,7 +21,7 @@ fn main() {
 	hostid := hd_get_hostid() & 0xffffffff
 
 	// Print as hexadecimal
-	println("${hostid.hex()}")
+	println('$hostid.hex()')
 
 	// Other flags
 	fp.remaining_parameters()

--- a/src/hostid/hostid.v
+++ b/src/hostid/hostid.v
@@ -1,0 +1,28 @@
+import common
+import os
+
+const (
+	app_name        = 'hostid'
+	app_description = 'Print the numeric identifier (in hexadecimal) of the current host.'
+)
+
+/*
+** hostid clone written in V
+** Original author: B. <SheatNoisette> Malhomme
+*/
+fn main() {
+	mut fp := common.flag_parser(os.args)
+	fp.application(app_name)
+	fp.description(app_description)
+
+	fp.limit_free_args(0, 0) ?
+
+	// Get hostid using wrapper
+	hostid := hd_get_hostid() & 0xffffffff
+
+	// Print as hexadecimal
+	println("${hostid.hex()}")
+
+	// Other flags
+	fp.remaining_parameters()
+}


### PR DESCRIPTION
Recreation of GNU Coreutils hostid, which print the hostid in hexadecimal.