### PR TITLE
Fix/Clear ongoing output buffer to prevent potentially filling memory

### DIFF
--- a/src/fold/fold.v
+++ b/src/fold/fold.v
@@ -86,6 +86,8 @@ fn (mut f Folder) flush() ? {
 	f.output_buf.write(f.pending_output)?
 	f.pending_output.clear()
 	f.column = 0
+	print(f.str())
+	f.output_buf.clear()
 }
 
 fn (mut f Folder) str() string {


### PR DESCRIPTION
At present, despite using a buffered reader to prevent trying to load a potentially huge file into memory, it does ironically however keep all of the file's contents and more (which could be larger than the available) in system memory for the duration of the program. The fix therefore is to continuously dump to stdout and clear the output buffer as we go.