### PR TITLE
feat: Check if a file has been modified in build.vsh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all prod fmt test testfmt
+.PHONY: all prod fmt test testfmt clean
 
 all:
 	@v run build.vsh
@@ -10,7 +10,10 @@ fmt:
 	v fmt -w .
 
 test:
-	LANG=C v test .	
+	LANG=C v test .
 
 testfmt:
 	v fmt -verify .
+
+clean:
+	$(RM) -r bin

--- a/build.vsh
+++ b/build.vsh
@@ -25,7 +25,21 @@ for dir in dirs {
 		continue
 	}
 
-	// TODO: don't build something if it is already built
+	// Get all of the of v files in the directory and get unix modifed time
+	mut modification_time := []i64{}
+	for src_file in ls(dir)!.filter(it.ends_with('.v')) {
+		modification_time << os.file_last_mod_unix('$dir/$src_file')
+	}
+
+	// Check if the binary exists and is newer than the source files
+	// If it is, skip it
+	if exists('$curdir/bin/$dir') {
+		bin_mod_time := os.file_last_mod_unix('$curdir/bin/$dir')
+		// If the binary is newer than the source files, skip it
+		if modification_time.filter(it < bin_mod_time).len == modification_time.len {
+			continue
+		}
+	}
 
 	mut final_args := '-Wimpure-v'
 	for arg in vargs {


### PR DESCRIPTION
A slight modifcation of build.vsh to check if the executable if newer or not. This improve build times to only compile the required files instead of a full rebuild every time. This also add a "clean" rule in the Makefile.