### PR TITLE
Fix WinOS story (build + CI + multiple utils)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,54 @@ name: Build and Test
 on: [push, pull_request]
 
 jobs:
+  winos-test:
+    runs-on: windows-latest
+    env:
+      VFLAGS: -cc tcc
+      VJOBS: 1
+      VTEST_SHOW_START: 1
+    steps:
+      - name: Checkout Latest V
+        uses: actions/checkout@v2
+        with:
+          repository: vlang/v
+          path: v
+      - name: Build V
+        shell: bash
+        run: |
+          # Build V
+          cd v && ./make.bat -tcc
+          # ls -Al
+          # ln -s v.exe vv
+          # ls -Al
+          echo "adding '${PWD}' to PATH"
+          echo "${PWD}" >> $GITHUB_PATH
+      - name: Checkout Coreutils (for tests)
+        uses: actions/checkout@v2
+        with:
+          path: coreutils
+      - name: V doctor
+        shell: bash
+        run: |
+          # V doctor
+          v doctor
+      - name: Build all
+        shell: bash
+        run: |
+          # Build all
+          cd coreutils && v build.vsh
+      - name: Download uutils/coreutils
+        uses: engineerd/configurator@v0.0.8
+        with:
+          name: 'coreutils.exe'
+          url: 'https://github.com/uutils/coreutils/releases/download/0.0.17/coreutils-0.0.17-x86_64-pc-windows-msvc.zip'
+          pathInArchive: 'coreutils-0.0.17-x86_64-pc-windows-msvc/coreutils.exe'
+      - name: Run tests
+        shell: bash
+        run: |
+          # Run tests
+          cd coreutils && v test .
+
   ubuntu-fast-build:
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +96,6 @@ jobs:
         run: cd coreutils && v run build.vsh -prod
       - name: Run tests
         run: cd coreutils && make test
-
 
   ubuntu-gnu-coreutils:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
       VJOBS: 1
       VTEST_SHOW_START: 1
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: coreutils
       - name: Checkout Latest V
         uses: actions/checkout@v2
         with:
@@ -20,31 +24,36 @@ jobs:
         run: |
           # Build V
           cd v && ./make.bat -tcc
-          # ls -Al
-          # ln -s v.exe vv
-          # ls -Al
           echo "adding '${PWD}' to PATH"
           echo "${PWD}" >> $GITHUB_PATH
-      - name: Checkout Coreutils (for tests)
-        uses: actions/checkout@v2
-        with:
-          path: coreutils
-      - name: V doctor
-        shell: bash
-        run: |
-          # V doctor
-          v doctor
-      - name: Build all
-        shell: bash
-        run: |
-          # Build all
-          cd coreutils && v build.vsh
       - name: Download uutils/coreutils
         uses: engineerd/configurator@v0.0.8
         with:
           name: 'coreutils.exe'
           url: 'https://github.com/uutils/coreutils/releases/download/0.0.17/coreutils-0.0.17-x86_64-pc-windows-msvc.zip'
           pathInArchive: 'coreutils-0.0.17-x86_64-pc-windows-msvc/coreutils.exe'
+      - name: V doctor
+        shell: bash
+        run: |
+          # V doctor
+          v doctor
+      - name: Info
+        shell: bash
+        run: |
+          ## Info
+          # environment
+          echo "## environment"
+          echo "CI='${CI}'"
+          # tooling info display
+          echo "## testing/tooling"
+          coreutils
+          which tcc >/dev/null 2>&1 && (tcc --version | head -1) || true
+          v --version
+      - name: Build all
+        shell: bash
+        run: |
+          # Build all
+          cd coreutils && v build.vsh
       - name: Run tests
         shell: bash
         run: |

--- a/build.vsh
+++ b/build.vsh
@@ -5,7 +5,7 @@ import os // v has a bug that you can't use args
 const (
 	ignore_dirs = $if windows {
 		// avoid utmp-dependent utils (WinOS has no utmp support)
-		['uptime', 'users', 'who', 'whoami']
+		['uptime', 'users', 'who']
 	} $else {
 		[]string{}
 	}

--- a/build.vsh
+++ b/build.vsh
@@ -51,7 +51,7 @@ for dir in dirs {
 		final_args += ' ' + arg
 	}
 	println('compiling ${dir}...')
-	cmd := 'v ${final_args} -o ${curdir}/bin/${dir} ./${dir}'
+	cmd := @VEXE + ' ${final_args} -o ${curdir}/bin/${dir} ./${dir}'
 	execute_or_panic(cmd)
 }
 

--- a/build.vsh
+++ b/build.vsh
@@ -4,8 +4,14 @@ import os // v has a bug that you can't use args
 
 const (
 	ignore_dirs = $if windows {
-		// avoid utmp-dependent utils (WinOS has no utmp support)
-		['uptime', 'users', 'who']
+		[
+			// avoid *nix-dependent utils
+			'nohup',
+			// avoid utmp-dependent utils (WinOS has no utmp support)
+			'uptime',
+			'users',
+			'who',
+		]
 	} $else {
 		[]string{}
 	}

--- a/common/common.c.v
+++ b/common/common.c.v
@@ -4,6 +4,15 @@ module common
 
 fn C.setlocale(category int, locale &char) &char
 
+// ref: <https://stackoverflow.com/questions/57131654/using-utf-8-encoding-chcp-65001-in-command-prompt-windows-powershell-window>
+// ref: <https://stackoverflow.com/questions/388490/how-to-use-unicode-characters-in-windows-command-line>
+// ref: <https://stackoverflow.com/questions/64939841/script-to-detect-if-windows-system-locale-is-using-utf-8-code-page>
+// ref: <https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale> @@ <https://archive.is/43ucb>
+
+fn C.GetACP() u32 // ref: <https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getacp> @@ <https://archive.is/kaMaR>
+fn C.GetConsoleOutputCP() u32 // ref: <https://learn.microsoft.com/en-us/windows/console/getconsoleoutputcp> @@ <https://archive.is/wymp0>
+fn C.GetOEMCP() u32 // ref: <https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getoemcp> @@ <https://archive.is/Cvtvm>
+
 fn init() {
 	C.setlocale(C.LC_ALL, ''.str)
 }
@@ -11,5 +20,9 @@ fn init() {
 // is_utf8 returns whether the locale supports UTF-8 or not
 pub fn is_utf8() bool {
 	locale := unsafe { C.setlocale(C.LC_CTYPE, &char(0)).vstring().to_lower() }
-	return locale.contains_any_substr(['utf8', 'utf-8'])
+	return locale.contains_any_substr(['utf8', 'utf-8']) || $if windows {
+		(C.GetACP() == 65001) || (C.GetConsoleOutputCP() == 65001) || (C.GetOEMCP() == 65001)
+	} $else {
+		false
+	}
 }

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -175,6 +175,15 @@ pub fn same_results(cmd1 string, cmd2 string) bool {
 	if cmd1.contains('printenv') && cmd2.contains('printenv.exe') {
 		return cmd1_res.exit_code == cmd2_res.exit_code
 	}
+	if cmd1.contains('sleep') {
+		after1 := noutput1.replace(': invalid float literal', '')
+		after2 := noutput2
+		$if trace_same_results ? {
+			eprintln('                after1.len: ${after1.len} | "${after1}"')
+			eprintln('                after2.len: ${after2.len} | "${after2}"')
+		}
+		return cmd1_res.exit_code == cmd2_res.exit_code && after1 == after2
+	}
 	if cmd1 == 'uptime' || cmd1 == 'uptime /var/log/wtmp' {
 		after1 := cmd1_res.output.all_after('load average:')
 		after2 := cmd2_res.output.all_after('load average:')

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -152,10 +152,10 @@ pub fn same_results(cmd1 string, cmd2 string) bool {
 		eprintln('>> same_results cmd2: "${cmd2}"')
 		eprintln('                cmd1_res.exit_code: ${cmd1_res.exit_code}')
 		eprintln('                cmd2_res.exit_code: ${cmd2_res.exit_code}')
-		eprintln('                cmd1_res.output.len: ${cmd1_res.output.len} | "${noutput1}"')
-		eprintln('                cmd2_res.output.len: ${cmd2_res.output.len} | "${noutput2}"')
-		eprintln('              > cmd1_res.output.len: ${cmd1_res.output.len} | "${cmd1_res.output}"')
-		eprintln('              > cmd2_res.output.len: ${cmd2_res.output.len} | "${cmd2_res.output}"')
+		eprintln('                cmd1_res.output.len: ${noutput1.len} | "${noutput1}"')
+		eprintln('                cmd2_res.output.len: ${noutput2.len} | "${noutput2}"')
+		eprintln('        (raw) > cmd1_res.output.len: ${cmd1_res.output.len} | "${cmd1_res.output}"')
+		eprintln('        (raw) > cmd2_res.output.len: ${cmd2_res.output.len} | "${cmd2_res.output}"')
 	}
 	if testing.gnu_coreutils_installed {
 		// aim for 1:1 output compatibility:

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -162,6 +162,16 @@ pub fn same_results(cmd1 string, cmd2 string) bool {
 		return cmd1_res.exit_code == cmd2_res.exit_code && cmd1_res.output == cmd2_res.output
 	}
 	// relax the strict matching for well known exceptions:
+	if cmd1.contains('arch') {
+		// `arch` is not standardized and 'AMD64' is more commonly known as 'x86_64'
+		after1 := noutput1
+		after2 := noutput2.replace('AMD64', 'x86_64')
+		$if trace_same_results ? {
+			eprintln('                after1.len: ${after1.len} | "${after1}"')
+			eprintln('                after2.len: ${after2.len} | "${after2}"')
+		}
+		return cmd1_res.exit_code == cmd2_res.exit_code && after1 == after2
+	}
 	if cmd1.contains('printenv') && cmd2.contains('printenv.exe') {
 		return cmd1_res.exit_code == cmd2_res.exit_code
 	}

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -180,9 +180,18 @@ pub fn same_results(cmd1 string, cmd2 string) bool {
 
 fn normalise(s string) string {
 	return s.replace_each(['‘', "'", '’', "'"]).replace('  ', ' ').replace('  ', ' ').replace('  ',
-		' ').replace(', ', ' ')
+		' ').replace(', ', ' ').split_into_lines().join('\n').trim_space()
 }
 
 pub fn check_dir_exists(d string) bool {
 	return os.exists(d) && os.is_dir(d)
+}
+
+pub fn output_eol() string {
+	$if windows {
+		// WinOS => CRLF
+		return '\r\n'
+	}
+	// POSIX => LF
+	return '\n'
 }

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -1,6 +1,7 @@
 module testing
 
 import os
+import regex
 
 // The ...Error structs here implement IError,
 // so that they can be used as more specific errors,
@@ -144,8 +145,8 @@ const gnu_coreutils_installed = os.getenv('GNU_COREUTILS_INSTALLED').int() == 1
 pub fn same_results(cmd1 string, cmd2 string) bool {
 	mut cmd1_res := os.execute(cmd1)
 	mut cmd2_res := os.execute(cmd2)
-	noutput1 := normalise(cmd1_res.output)
-	noutput2 := normalise(cmd2_res.output)
+	mut noutput1 := normalise(cmd1_res.output)
+	mut noutput2 := normalise(cmd2_res.output)
 	$if trace_same_results ? {
 		eprintln('------------------------------------')
 		eprintln('>> same_results cmd1: "${cmd1}"')
@@ -164,34 +165,42 @@ pub fn same_results(cmd1 string, cmd2 string) bool {
 	// relax the strict matching for well known exceptions:
 	if cmd1.contains('arch') {
 		// `arch` is not standardized and 'AMD64' is more commonly known as 'x86_64'
-		after1 := noutput1
-		after2 := noutput2.replace('AMD64', 'x86_64')
+		mut re := regex.regex_opt('[aA][mM][dD]64') or { panic(err) }
+		// noutput1 = noutput1
+		noutput2 = re.replace(noutput2, 'x86_64')
 		$if trace_same_results ? {
-			eprintln('                after1.len: ${after1.len} | "${after1}"')
-			eprintln('                after2.len: ${after2.len} | "${after2}"')
+			eprintln('                 (arch) after1: ${noutput1.len} | "${noutput1}"')
+			eprintln('                 (arch) after2: ${noutput2.len} | "${noutput2}"')
 		}
-		return cmd1_res.exit_code == cmd2_res.exit_code && after1 == after2
 	}
 	if cmd1.contains('printenv') && cmd2.contains('printenv.exe') {
 		return cmd1_res.exit_code == cmd2_res.exit_code
 	}
 	if cmd1.contains('sleep') {
-		after1 := noutput1.replace(': invalid float literal', '')
-		after2 := noutput2
+		noutput1 = noutput1.replace(': invalid float literal', '')
+		// noutput2 = noutput2
 		$if trace_same_results ? {
-			eprintln('                after1.len: ${after1.len} | "${after1}"')
-			eprintln('                after2.len: ${after2.len} | "${after2}"')
+			eprintln('                (sleep) after1: ${noutput1.len} | "${noutput1}"')
+			eprintln('                (sleep) after2: ${noutput2.len} | "${noutput2}"')
 		}
-		return cmd1_res.exit_code == cmd2_res.exit_code && after1 == after2
+	}
+	if cmd1.contains('uname') {
+		// `uname` is not standardized and 'AMD64' is more commonly known as 'x86_64'
+		mut re := regex.regex_opt('[aA][mM][dD]64') or { panic(err) }
+		// noutput1 = noutput1
+		noutput2 = re.replace(noutput2, 'x86_64')
+		$if trace_same_results ? {
+			eprintln('                 (arch) after1: ${noutput1.len} | "${noutput1}"')
+			eprintln('                 (arch) after2: ${noutput2.len} | "${noutput2}"')
+		}
 	}
 	if cmd1 == 'uptime' || cmd1 == 'uptime /var/log/wtmp' {
-		after1 := cmd1_res.output.all_after('load average:')
-		after2 := cmd2_res.output.all_after('load average:')
+		noutput1 = cmd1_res.output.all_after('load average:')
+		noutput2 = cmd2_res.output.all_after('load average:')
 		$if trace_same_results ? {
-			eprintln('                after1.len: ${after1.len} | "${after1}"')
-			eprintln('                after2.len: ${after2.len} | "${after2}"')
+			eprintln('               (uptime) after1: ${noutput1.len} | "${noutput1}"')
+			eprintln('               (uptime) after2: ${noutput2.len} | "${noutput2}"')
 		}
-		return cmd1_res.exit_code == cmd2_res.exit_code && after1 == after2
 	}
 	// in all other cases, compare the normalised output (less strict):
 	return cmd1_res.exit_code == cmd2_res.exit_code && noutput1 == noutput2

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -163,6 +163,14 @@ pub fn same_results(cmd1 string, cmd2 string) bool {
 		return cmd1_res.exit_code == cmd2_res.exit_code && cmd1_res.output == cmd2_res.output
 	}
 	// relax the strict matching for well known exceptions:
+	if cmd1.contains('coreutils') {
+		noutput1 = noutput1.replace("'coreutils ", "'")
+		// noutput2 = noutput2
+		$if trace_same_results ? {
+			eprintln('                 (coreutils) after1: ${noutput1.len} | "${noutput1}"')
+			eprintln('                 (coreutils) after2: ${noutput2.len} | "${noutput2}"')
+		}
+	}
 	if cmd1.contains('arch') {
 		// `arch` is not standardized and 'AMD64' is more commonly known as 'x86_64'
 		mut re := regex.regex_opt('[aA][mM][dD]64') or { panic(err) }

--- a/src/arch/arch_test.v
+++ b/src/arch/arch_test.v
@@ -1,19 +1,19 @@
 import common.testing
 
-const the_executable = testing.prepare_executable('arch')
+const executable_under_test = testing.prepare_executable('arch')
 
-const cmd = testing.new_paired_command('arch', the_executable)
+const cmd = testing.new_paired_command('arch', executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_unknown_option() {
-	testing.command_fails('${the_executable} -x')!
+	testing.command_fails('${executable_under_test} -x')!
 }
 
 fn test_redundant_argument() {
-	testing.command_fails('${the_executable} x')!
+	testing.command_fails('${executable_under_test} x')!
 }
 
 fn test_print_machine_arch() {

--- a/src/arch/arch_test.v
+++ b/src/arch/arch_test.v
@@ -1,8 +1,16 @@
 import common.testing
 
-const executable_under_test = testing.prepare_executable('arch')
+const util = 'arch'
 
-const cmd = testing.new_paired_command('arch', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/base64/base64_test.v
+++ b/src/base64/base64_test.v
@@ -1,9 +1,17 @@
 import os
 import common.testing
 
-const executable_under_test = testing.prepare_executable('base64')
+const util = 'base64'
 
-const cmd = testing.new_paired_command('base64', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/base64/base64_test.v
+++ b/src/base64/base64_test.v
@@ -19,13 +19,13 @@ fn expected_result(input string, output string) {
 	c := '${the_executable} ${input}'
 	res := os.execute(c)
 	eprintln('>>>> cmd: `${c}`')
-	if res.exit_code != 0 || res.output != output {
+	if res.exit_code != 0 || res.output.split_into_lines() != output.split_into_lines() {
 		eprintln('>>>> res.exit_code: ${res.exit_code}')
 		eprintln('>>>> res.output   : `${res.output}`')
 		eprintln('>>>> expected     : `${output}`')
 	}
 	assert res.exit_code == 0
-	assert res.output == output
+	assert res.output.split_into_lines() == output.split_into_lines()
 	testing.same_results('base64 ${input}', '${the_executable} ${input}')
 }
 

--- a/src/base64/base64_test.v
+++ b/src/base64/base64_test.v
@@ -1,22 +1,22 @@
 import os
 import common.testing
 
-const the_executable = testing.prepare_executable('base64')
+const executable_under_test = testing.prepare_executable('base64')
 
-const cmd = testing.new_paired_command('base64', the_executable)
+const cmd = testing.new_paired_command('base64', executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_abcd() {
-	res := os.execute('${the_executable} abcd')
+	res := os.execute('${executable_under_test} abcd')
 	assert res.exit_code == 1
 	assert res.output.trim_space() == 'base64: abcd: No such file or directory'
 }
 
 fn expected_result(input string, output string) {
-	c := '${the_executable} ${input}'
+	c := '${executable_under_test} ${input}'
 	res := os.execute(c)
 	eprintln('>>>> cmd: `${c}`')
 	if res.exit_code != 0 || res.output.split_into_lines() != output.split_into_lines() {
@@ -26,7 +26,7 @@ fn expected_result(input string, output string) {
 	}
 	assert res.exit_code == 0
 	assert res.output.split_into_lines() == output.split_into_lines()
-	testing.same_results('base64 ${input}', '${the_executable} ${input}')
+	testing.same_results('base64 ${input}', '${executable_under_test} ${input}')
 }
 
 fn test_expected() {

--- a/src/expr/expr.v
+++ b/src/expr/expr.v
@@ -19,7 +19,7 @@ Options:
   --help                   display this help and exit
   --version                output version information and exit'
 
-const locale = common.is_utf8()
+const useUTF = common.is_utf8()
 
 type Value = i64 | string
 
@@ -205,7 +205,7 @@ fn match_str(s string, _m string) Value {
 	} else {
 		return i64(if start == -1 {
 			0
-		} else if locale {
+		} else if useUTF {
 			s[start..end].len_utf8()
 		} else {
 			end - start
@@ -285,7 +285,7 @@ fn (mut p Parser) primary() Value {
 			if pos < 1 || len < 1 {
 				return ''
 			}
-			if locale {
+			if useUTF {
 				ustr := str.runes()
 				start := if ustr.len < pos - 1 { i64(ustr.len) } else { pos - 1 }
 				end := if ustr.len < start + len { i64(ustr.len) } else { start + len }
@@ -301,7 +301,7 @@ fn (mut p Parser) primary() Value {
 		'index' {
 			str := p.primary().str()
 			chr := p.primary().str()
-			if locale {
+			if useUTF {
 				ustr := str.runes()
 				uchr := chr.runes()
 				for i, r in ustr {
@@ -321,7 +321,7 @@ fn (mut p Parser) primary() Value {
 		}
 		'length' {
 			val := p.primary().str()
-			return i64(if locale {
+			return i64(if useUTF {
 				val.len_utf8()
 			} else {
 				val.len

--- a/src/expr/expr.v
+++ b/src/expr/expr.v
@@ -19,7 +19,7 @@ Options:
   --help                   display this help and exit
   --version                output version information and exit'
 
-const useUTF = common.is_utf8()
+const use_utf = common.is_utf8()
 
 type Value = i64 | string
 
@@ -205,7 +205,7 @@ fn match_str(s string, _m string) Value {
 	} else {
 		return i64(if start == -1 {
 			0
-		} else if useUTF {
+		} else if use_utf {
 			s[start..end].len_utf8()
 		} else {
 			end - start
@@ -285,7 +285,7 @@ fn (mut p Parser) primary() Value {
 			if pos < 1 || len < 1 {
 				return ''
 			}
-			if useUTF {
+			if use_utf {
 				ustr := str.runes()
 				start := if ustr.len < pos - 1 { i64(ustr.len) } else { pos - 1 }
 				end := if ustr.len < start + len { i64(ustr.len) } else { start + len }
@@ -301,7 +301,7 @@ fn (mut p Parser) primary() Value {
 		'index' {
 			str := p.primary().str()
 			chr := p.primary().str()
-			if useUTF {
+			if use_utf {
 				ustr := str.runes()
 				uchr := chr.runes()
 				for i, r in ustr {
@@ -321,7 +321,7 @@ fn (mut p Parser) primary() Value {
 		}
 		'length' {
 			val := p.primary().str()
-			return i64(if useUTF {
+			return i64(if use_utf {
 				val.len_utf8()
 			} else {
 				val.len

--- a/src/expr/expr_test.v
+++ b/src/expr/expr_test.v
@@ -1,3 +1,4 @@
+import common
 import common.testing
 import os
 
@@ -187,22 +188,26 @@ const mb_tests = [
 ]
 
 fn test_multi_byte_results() {
+	use_utf := common.is_utf8()
 	mut failed := []string{}
-	for test in mb_tests {
-		res := cmd.same_results(test)
-		if !res {
-			original_cmd := '${cmd.original} ${test}'
-			deputy_cmd := '${cmd.deputy} ${test}'
-			ores := os.execute(original_cmd)
-			dres := os.execute(deputy_cmd)
-			if ores.exit_code == 2 && dres.exit_code == 2 {
-				continue
+	if use_utf {
+		// attempt multi-byte tests iff utf is enabled/used
+		for test in mb_tests {
+			res := cmd.same_results(test)
+			if !res {
+				original_cmd := '${cmd.original} ${test}'
+				deputy_cmd := '${cmd.deputy} ${test}'
+				ores := os.execute(original_cmd)
+				dres := os.execute(deputy_cmd)
+				if ores.exit_code == 2 && dres.exit_code == 2 {
+					continue
+				}
+				failed << test
+				eprintln('>>> original_cmd: `${original_cmd}`')
+				eprintln('>>>   deputy_cmd: `${deputy_cmd}`')
+				eprintln('>>>    fail_ores: ${ores}')
+				eprintln('>>>    fail_dres: ${dres}')
 			}
-			failed << test
-			eprintln('>>> original_cmd: `${original_cmd}`')
-			eprintln('>>>   deputy_cmd: `${deputy_cmd}`')
-			eprintln('>>>    fail_ores: ${ores}')
-			eprintln('>>>    fail_dres: ${dres}')
 		}
 	}
 	println(failed.join('\n'))

--- a/src/expr/expr_test.v
+++ b/src/expr/expr_test.v
@@ -49,9 +49,11 @@ const tests = [
 	r'"a)" : "a)"',
 	r'_ : "a\\)"'
 	//	r'_ : "\\)"',
-	r'"ab" : "a\\(\\)b"',
-	r'"a^b" : "a^b"',
-	r'"a\$b" : "a\$b"',
+	r'"ab" : "a\\(\\)b"'
+	// r'"a^b" : "a^b"',       // FixME: [2022-12-29; rivy] for WinOS comparison, `expr.exe` is bugged based on oniguruma bug (see GH:kkos/oniguruma/issues/279)
+	r'"a^b" : "a\^b"'
+	// r'"a\$b" : "a\\$b"',    // FixME: [2022-12-29; rivy] for WinOS comparison, `expr.exe` is bugged based on oniguruma bug (see GH:kkos/oniguruma/issues/279)
+	r'"a\$b" : a[$]b',
 	r'"" : "\\($\\)\\(^\\)"'
 	//	r'"b" : "a*\\(^b\$\\)c*"',
 	r'"X|" : "X\\(|\\)" : "(" "X|" : "X\\(|\\)" ")"'

--- a/src/expr/expr_test.v
+++ b/src/expr/expr_test.v
@@ -1,9 +1,9 @@
 import common.testing
 import os
 
-const the_executable = testing.prepare_executable('expr')
+const executable_under_test = testing.prepare_executable('expr')
 
-const cmd = testing.new_paired_command('expr', the_executable)
+const cmd = testing.new_paired_command('expr', executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/expr/expr_test.v
+++ b/src/expr/expr_test.v
@@ -1,9 +1,17 @@
 import common.testing
 import os
 
-const executable_under_test = testing.prepare_executable('expr')
+const util = 'expr'
 
-const cmd = testing.new_paired_command('expr', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/expr/expr_test.v
+++ b/src/expr/expr_test.v
@@ -104,7 +104,9 @@ const tests = [
 	//	r'"aa" : "a*\\{1\\}"',
 	//	r'"aa" : "a\\{1\\}*"'
 	//	r'"acd" : "a\\(b\\)?c\\1d"',
-	r'"-5" : "-\\{0,1\\}[0-9]*\$"',
+	// r'"-5" : "-\\{0,1\\}[0-9]*\$"', // DISABLED: escaping non-special characters in regex has undefined behavior
+	r'"-5" : "-\{0,1\}[0-9]*$"',
+	r'"-5" : "-\{0,1}[0-9]*$"',
 	r''
 	// big number is not supported for now
 	//	r'98782897298723498732987928734 + 1',

--- a/src/factor/factor_test.v
+++ b/src/factor/factor_test.v
@@ -1,9 +1,17 @@
 import os
 import common.testing
 
-const executable_under_test = testing.prepare_executable('factor')
+const util = 'factor'
 
-const cmd = testing.new_paired_command('factor', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/factor/factor_test.v
+++ b/src/factor/factor_test.v
@@ -1,25 +1,25 @@
 import os
 import common.testing
 
-const the_executable = testing.prepare_executable('factor')
+const executable_under_test = testing.prepare_executable('factor')
 
-const cmd = testing.new_paired_command('factor', the_executable)
+const cmd = testing.new_paired_command('factor', executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_abcd() {
-	res := os.execute('${the_executable} abcd')
+	res := os.execute('${executable_under_test} abcd')
 	assert res.exit_code == 1
 	assert res.output.trim_space() == 'factor: ‘abcd’ is not a valid positive integer'
 }
 
 fn expected_result(input string, output []string) {
-	res := os.execute('${the_executable} ${input}')
+	res := os.execute('${executable_under_test} ${input}')
 	assert res.exit_code == 0
 	assert res.output.split_into_lines() == output
-	testing.same_results('factor ${input}', '${the_executable} ${input}')
+	testing.same_results('factor ${input}', '${executable_under_test} ${input}')
 }
 
 fn test_expected() {

--- a/src/fold/fold_test.v
+++ b/src/fold/fold_test.v
@@ -3,9 +3,17 @@ import common.testing
 
 const eol = testing.output_eol()
 
-const executable_under_test = testing.prepare_executable('fold')
+const util = 'fold'
 
-const cmd = testing.new_paired_command('fold', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 const test_txt_path = os.join_path(testing.temp_folder, 'test.txt')
 

--- a/src/fold/fold_test.v
+++ b/src/fold/fold_test.v
@@ -1,6 +1,8 @@
 import os
 import common.testing
 
+const eol = testing.output_eol()
+
 const executable_under_test = testing.prepare_executable('fold')
 
 const cmd = testing.new_paired_command('fold', executable_under_test)
@@ -12,9 +14,9 @@ fn test_help_and_version() {
 }
 
 fn testsuite_begin() {
-	mut f := os.open_file(test_txt_path, 'w')!
+	mut f := os.open_file(test_txt_path, 'wb')!
 	for l in testtxtcontent {
-		f.write_string('${l}\n') or {}
+		f.writeln('${l}') or {}
 	}
 	f.close()
 }
@@ -32,7 +34,7 @@ fn test_non_existent_file() {
 fn test_non_existent_files() {
 	res := os.execute('${executable_under_test} non-existent-file second-non-existent-file')
 	assert res.exit_code == 1
-	assert res.output.trim_space() == 'fold: failed to open file "non-existent-file"\nfold: failed to open file "second-non-existent-file"'
+	assert res.output.trim_space() == 'fold: failed to open file "non-existent-file"${eol}fold: failed to open file "second-non-existent-file"'
 }
 
 const testtxtcontent = [
@@ -51,7 +53,7 @@ const testtxtcontent = [
 fn test_wrap_default() {
 	res := os.execute('${executable_under_test} ${test_txt_path}')
 	assert res.exit_code == 0
-	assert res.output.split('\n').filter(it != '') == [
+	assert res.output.split_into_lines().filter(it != '') == [
 		'[0] Example test line',
 		'[1] Example test line',
 		'[2] Example test line',
@@ -68,7 +70,7 @@ fn test_wrap_default() {
 fn test_wrap_multiline_file_with_width_10() {
 	res := os.execute('${executable_under_test} ${test_txt_path} -w 10')
 	assert res.exit_code == 0
-	assert res.output.split('\n').filter(it != '') == [
+	assert res.output.split_into_lines().filter(it != '') == [
 		'[0] Exampl',
 		'e test lin',
 		'e',
@@ -105,7 +107,7 @@ fn test_wrap_multiline_file_with_width_10() {
 fn test_wrap_multiline_file_with_width_3() {
 	res := os.execute('${executable_under_test} ${test_txt_path} -w 3')
 	assert res.exit_code == 0
-	assert res.output.split('\n').filter(it != '') == [
+	assert res.output.split_into_lines().filter(it != '') == [
 		'[0]',
 		' Ex',
 		'amp',

--- a/src/head/head_test.v
+++ b/src/head/head_test.v
@@ -3,9 +3,17 @@ import common.testing
 
 const eol = testing.output_eol()
 
-const executable_under_test = testing.prepare_executable('head')
+const util = 'head'
 
-const cmd = testing.new_paired_command('head', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 const test_txt_path = os.join_path(testing.temp_folder, 'test.txt')
 

--- a/src/head/head_test.v
+++ b/src/head/head_test.v
@@ -1,6 +1,8 @@
 import os
 import common.testing
 
+const eol = testing.output_eol()
+
 const executable_under_test = testing.prepare_executable('head')
 
 const cmd = testing.new_paired_command('head', executable_under_test)
@@ -8,9 +10,9 @@ const cmd = testing.new_paired_command('head', executable_under_test)
 const test_txt_path = os.join_path(testing.temp_folder, 'test.txt')
 
 fn testsuite_begin() {
-	mut f := os.open_file(test_txt_path, 'w')!
+	mut f := os.open_file(test_txt_path, 'wb')!
 	for l in testtxtcontent {
-		f.write_string('${l}\n')!
+		f.writeln('${l}')!
 	}
 	f.close()
 }
@@ -32,7 +34,7 @@ fn test_non_existent_file() {
 fn test_non_existent_files() {
 	res := os.execute('${executable_under_test} non-existent-file second-non-existent-file')
 	assert res.exit_code == 1
-	assert res.output.trim_space() == 'head: failed to open file "non-existent-file"\nhead: failed to open file "second-non-existent-file"'
+	assert res.output.trim_space() == 'head: failed to open file "non-existent-file"${eol}head: failed to open file "second-non-existent-file"'
 }
 
 const testtxtcontent = [
@@ -54,7 +56,7 @@ const testtxtcontent = [
 fn test_default() {
 	res := os.execute('${executable_under_test} ${test_txt_path}')
 	assert res.exit_code == 0
-	assert res.output.split('\n').filter(it != '') == [
+	assert res.output.split_into_lines().filter(it != '') == [
 		'[0] Line in test text file',
 		'[1] Line in test text file',
 		'[2] Line in test text file',
@@ -71,7 +73,7 @@ fn test_default() {
 fn test_max_lines_option() {
 	res := os.execute('${executable_under_test} ${test_txt_path} -n 4')
 	assert res.exit_code == 0
-	assert res.output.split('\n').filter(it != '') == [
+	assert res.output.split_into_lines().filter(it != '') == [
 		'[0] Line in test text file',
 		'[1] Line in test text file',
 		'[2] Line in test text file',
@@ -82,7 +84,7 @@ fn test_max_lines_option() {
 fn test_max_lines_from_end_option() {
 	res := os.execute('${executable_under_test} ${test_txt_path} -n -4')
 	assert res.exit_code == 0
-	assert res.output.split('\n').filter(it != '') == [
+	assert res.output.split_into_lines().filter(it != '') == [
 		'[0] Line in test text file',
 		'[1] Line in test text file',
 		'[2] Line in test text file',
@@ -98,7 +100,7 @@ fn test_max_lines_from_end_option() {
 fn test_upto_max_bytes() {
 	res := os.execute('${executable_under_test} ${test_txt_path} -c 223')
 	assert res.exit_code == 0
-	assert res.output.split('\n').filter(it != '') == [
+	assert res.output.split_into_lines().filter(it != '') == [
 		'[0] Line in test text file',
 		'[1] Line in test text file',
 		'[2] Line in test text file',
@@ -114,7 +116,7 @@ fn test_upto_max_bytes() {
 fn test_upto_max_bytes_from_end_option() {
 	res := os.execute('${executable_under_test} ${test_txt_path} -c -312')
 	assert res.exit_code == 0
-	assert res.output.split('\n').filter(it != '') == [
+	assert res.output.split_into_lines().filter(it != '') == [
 		'[0] Line in test text file',
 		'[1] Line in tes',
 	]

--- a/src/mkdir/mkdir_test.v
+++ b/src/mkdir/mkdir_test.v
@@ -30,9 +30,17 @@ fn testsuite_end() {
 	eprintln('testsuite_end  , tfolder = ${tfolder} removed.')
 }
 
-const executable_under_test = testing.prepare_executable('mkdir')
+const util = 'mkdir'
 
-const cmd = testing.new_paired_command('mkdir', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/mkdir/mkdir_test.v
+++ b/src/mkdir/mkdir_test.v
@@ -1,6 +1,8 @@
 import os
 import common.testing
 
+const eol = testing.output_eol()
+
 // A lot of the following has been lifted directly from os_test.v in vlib,
 // since it is a good demonstration of the ideal/canonical method of testing
 // functionality that interacts with the file sys.
@@ -67,7 +69,7 @@ fn test_default_create_multiple_dirs_with_verbose() {
 	second_test_dir_to_make := 'secondtestdir'
 	res := os.execute('${executable_under_test} -v ${first_test_dir_to_make} ${second_test_dir_to_make}')
 	assert res.exit_code == 0
-	assert res.output.trim_space() == "mkdir: created directory 'testdir'\nmkdir: created directory 'secondtestdir'"
+	assert res.output.trim_space() == "mkdir: created directory 'testdir'${eol}mkdir: created directory 'secondtestdir'"
 	assert testing.check_dir_exists(first_test_dir_to_make)
 	assert testing.check_dir_exists(second_test_dir_to_make)
 
@@ -90,9 +92,10 @@ fn test_create_dir_with_parents_and_flag() {
 
 fn test_create_dir_with_parents_without_flag_fails() {
 	test_dir_to_make := os.join_path('parent-two', 'child-two', 'last-child')
+	output_path := os.norm_path(test_dir_to_make)
 	res := os.execute('${executable_under_test} ${test_dir_to_make}')
 	assert res.exit_code == 1
-	assert res.output.trim_space() == "mkdir: cannot create directory 'parent-two/child-two/last-child': No such file or directory"
+	assert res.output.trim_space() == "mkdir: cannot create directory '${output_path}': No such file or directory"
 	assert !testing.check_dir_exists(test_dir_to_make)
 	os.rmdir_all(test_dir_to_make) or { eprintln("failed to remove '${test_dir_to_make}'") }
 }

--- a/src/printenv/printenv_test.v
+++ b/src/printenv/printenv_test.v
@@ -1,8 +1,16 @@
 import common.testing
 
-const executable_under_test = testing.prepare_executable('printenv')
+const util = 'printenv'
 
-const cmd = testing.new_paired_command('printenv', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/printenv/printenv_test.v
+++ b/src/printenv/printenv_test.v
@@ -1,15 +1,15 @@
 import common.testing
 
-const the_executable = testing.prepare_executable('printenv')
+const executable_under_test = testing.prepare_executable('printenv')
 
-const cmd = testing.new_paired_command('printenv', the_executable)
+const cmd = testing.new_paired_command('printenv', executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_unknown_option() {
-	testing.command_fails('${the_executable} -x')!
+	testing.command_fails('${executable_under_test} -x')!
 }
 
 fn test_print_all_default() {

--- a/src/shuf/shuf_test.v
+++ b/src/shuf/shuf_test.v
@@ -1,19 +1,21 @@
 import os
 import common.testing
 
+const eol = testing.output_eol()
+
 const shuf = testing.prepare_executable('shuf')
 
 const test_txt_path = os.join_path(testing.temp_folder, 'test.txt')
 
 fn test_echo() {
 	res := os.execute('${shuf} -e aa bb')
-	assert (res.output == 'aa\nbb\n') || (res.output == 'bb\naa\n')
+	assert (res.output == 'aa${eol}bb${eol}') || (res.output == 'bb${eol}aa${eol}')
 }
 
 fn test_file() {
 	os.write_file(test_txt_path, 'hello\nworld!')!
 	res := os.execute('${shuf} ${test_txt_path}')
-	assert (res.output == 'hello\nworld!\n') || (res.output == 'world!\nhello\n')
+	assert (res.output == 'hello${eol}world!${eol}') || (res.output == 'world!${eol}hello${eol}')
 }
 
 fn test_zero_terminated_echo() {
@@ -24,24 +26,24 @@ fn test_zero_terminated_echo() {
 fn test_zero_terminated_file() {
 	os.write_file(test_txt_path, 'hello\nworld!')!
 	res := os.execute('${shuf} -z ${test_txt_path}')
-	assert res.output == 'hello\nworld!'
+	assert res.output == 'hello${eol}world!'
 }
 
 fn test_head_count() {
 	res := os.execute('${shuf} -n 5 -i 1-10')
-	println(res.output.split('\n'))
-	assert res.output.split('\n').len - 1 == 5
+	println(res.output.split_into_lines())
+	assert res.output.split_into_lines().len == 5
 }
 
 fn test_input_range() {
 	res := os.execute('${shuf} -i 1-10')
-	assert res.output.split('\n').len - 1 == 10
+	assert res.output.split_into_lines().len == 10
 }
 
 fn test_random_source() {
 	os.write_file(test_txt_path, 'hello\nworld!')!
 	res := os.execute('${shuf} -i 1-5 --random-source ${test_txt_path}')
-	assert res.output == '1\n4\n5\n2\n3\n'
+	assert res.output == '1${eol}4${eol}5${eol}2${eol}3${eol}'
 }
 
 fn test_unknown_option() ? {

--- a/src/sleep/sleep.v
+++ b/src/sleep/sleep.v
@@ -100,7 +100,7 @@ fn main() {
 		common.exit_with_error_message(cmd_ns, '')
 	}
 	// if seconds = +inf, it would not sleep
-	// but orginal `sleep` would sleep
+	// but original `sleep` would sleep
 	t := time.ticks()
 	time.sleep(seconds * time.second)
 	$if trace_sleep_ticks ? {

--- a/src/sleep/sleep.v
+++ b/src/sleep/sleep.v
@@ -1,7 +1,8 @@
+import math
 import os
 import regex
-import common
 import time
+import common
 
 const cmd_ns = 'sleep'
 
@@ -76,12 +77,12 @@ fn main() {
 			''
 		}
 		n_str := arg.trim_string_right(suffix)
-		if !is_decimal(n_str) {
+		if !(n_str == 'inf' || n_str == 'infinity') && !is_decimal(n_str) {
 			eprintln(invalid_time_interval_argument(arg))
 			ok = false
 			continue
 		}
-		n := n_str.f64() // unsafe { C.strtold(&char(arg.str), &endptr) }
+		n := if n_str == 'inf' || n_str == 'infinity' { math.inf(1) } else { n_str.f64() } // unsafe { C.strtold(&char(arg.str), &endptr) }
 		unit := suffix
 		if n < 0 {
 			eprintln(invalid_time_interval(n, unit))

--- a/src/sleep/sleep_test.v
+++ b/src/sleep/sleep_test.v
@@ -30,6 +30,17 @@ fn test_invalid_interval() {
 	assert res.exit_code == 1
 }
 
+fn test_valid_interval() {
+	assert cmd.same_results('0')
+	assert cmd.same_results('0s')
+	assert cmd.same_results('0.0')
+	assert cmd.same_results('0.0s')
+	assert cmd.same_results('0.1')
+	assert cmd.same_results('0.1s')
+	assert cmd.same_results('1')
+	assert cmd.same_results('1s')
+}
+
 fn test_interval() {
 	// 5e-7  * 86400 + 5e-7 * 3600 + 1e-4 * 60 + 1e-3 + 1e-3 = 0.053s = 53ms
 	x1 := time.ticks()

--- a/src/sleep/sleep_test.v
+++ b/src/sleep/sleep_test.v
@@ -2,9 +2,9 @@ import os
 import time
 import common.testing
 
-const the_executable = testing.prepare_executable('sleep')
+const executable_under_test = testing.prepare_executable('sleep')
 
-const cmd = testing.new_paired_command('sleep', the_executable)
+const cmd = testing.new_paired_command('sleep', executable_under_test)
 
 const cmd_ns = 'sleep'
 
@@ -13,7 +13,7 @@ fn test_help_and_version() {
 }
 
 fn test_unknown_option() {
-	res := os.execute('${the_executable} -x')
+	res := os.execute('${executable_under_test} -x')
 	assert res.exit_code == 1
 }
 
@@ -26,7 +26,7 @@ fn test_invalid_interval() {
 	assert cmd.same_results('1a')
 	assert cmd.same_results('1s0')
 	assert cmd.same_results('0.01 -- -1 0.01 1a 0.01 1s0')
-	res := os.execute('${the_executable} -1.7e+308')
+	res := os.execute('${executable_under_test} -1.7e+308')
 	assert res.exit_code == 1
 }
 
@@ -44,7 +44,7 @@ fn test_valid_interval() {
 fn test_interval() {
 	// 5e-7  * 86400 + 5e-7 * 3600 + 1e-4 * 60 + 1e-3 + 1e-3 = 0.053s = 53ms
 	x1 := time.ticks()
-	mut result_v := os.execute('${the_executable} 0.001 1e-3s 1e-4m 5e-7h 5e-7d')
+	mut result_v := os.execute('${executable_under_test} 0.001 1e-3s 1e-4m 5e-7h 5e-7d')
 	x2 := time.ticks()
 	delta_ms := x2 - x1
 	assert result_v.exit_code == 0

--- a/src/sleep/sleep_test.v
+++ b/src/sleep/sleep_test.v
@@ -2,9 +2,17 @@ import os
 import time
 import common.testing
 
-const executable_under_test = testing.prepare_executable('sleep')
+const util = 'sleep'
 
-const cmd = testing.new_paired_command('sleep', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 const cmd_ns = 'sleep'
 

--- a/src/uname/uname.v
+++ b/src/uname/uname.v
@@ -1,4 +1,5 @@
 import os
+import regex
 import common
 
 fn main() {
@@ -34,7 +35,25 @@ fn main() {
 		}
 	}
 	// Main functionality
-	uname := os.uname()
+	mut uname := os.uname()
+	// ToDO: [2023-01; rivy] remove this fix when os.uname is fixed
+	$if windows {
+		// compensate for os.uname "unique" values (as of "V 0.3.2 3625a74")
+		uname.sysname = 'Windows_NT'
+		// pull out version components from uname.release and uname.version
+		// * recipe works both for early "unique" os.uname variant and later more consistent (eg, "10.0" and "19040")
+		mut re := regex.regex_opt('[0-9]+')?
+		// mut version_components := re.find_all_str(uname.release + ' ' + uname.version + ' 10.0.0')
+		mut version_components := re.find_all_str(uname.version)
+		if version_components.len < 3 {
+			version_components.prepend(re.find_all_str(uname.release))
+		}
+		if version_components.len < 3 {
+			version_components = ['10', '0', '0']
+		}
+		uname.release = version_components[0..2].join('.')
+		uname.version = version_components[2]
+	}
 	mut result := []string{}
 	for addr, b in opt_map {
 		if b || opt_all {

--- a/src/uname/uname_test.v
+++ b/src/uname/uname_test.v
@@ -1,8 +1,16 @@
 import common.testing
 
-const executable_under_test = testing.prepare_executable('uname')
+const util = 'uname'
 
-const cmd = testing.new_paired_command('uname', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/uname/uname_test.v
+++ b/src/uname/uname_test.v
@@ -1,17 +1,17 @@
 import common.testing
 
-const the_executable = testing.prepare_executable('uname')
+const executable_under_test = testing.prepare_executable('uname')
 
-const cmd = testing.new_paired_command('uname', the_executable)
+const cmd = testing.new_paired_command('uname', executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_unknown_option() {
-	testing.command_fails('${the_executable} -x')!
-	testing.command_fails('${the_executable} -sm -vx')!
-	testing.command_fails('${the_executable} -sm a')!
+	testing.command_fails('${executable_under_test} -x')!
+	testing.command_fails('${executable_under_test} -sm -vx')!
+	testing.command_fails('${executable_under_test} -sm a')!
 }
 
 fn test_print_system_info() {

--- a/src/uptime/uptime_test.v
+++ b/src/uptime/uptime_test.v
@@ -8,13 +8,13 @@ const supported_platform = $if windows {
 	true
 } // WinOS lacks currently required utmp support
 
-const the_executable = if supported_platform {
+const executable_under_test = if supported_platform {
 	testing.prepare_executable(util)
 } else {
 	''
 }
 
-const cmd = testing.new_paired_command(util, the_executable)
+const cmd = testing.new_paired_command(util, executable_under_test)
 
 fn test_help_and_version() {
 	if !supported_platform {
@@ -27,7 +27,7 @@ fn test_unknown_option() {
 	if !supported_platform {
 		return
 	}
-	testing.command_fails('${the_executable} -x')!
+	testing.command_fails('${executable_under_test} -x')!
 }
 
 fn test_print_uptime() {

--- a/src/uptime/uptime_test.v
+++ b/src/uptime/uptime_test.v
@@ -1,18 +1,39 @@
 import common.testing
 
-const the_executable = testing.prepare_executable('uptime')
+const util = 'uptime'
 
-const cmd = testing.new_paired_command('uptime', the_executable)
+const supported_platform = $if windows {
+	false
+} $else {
+	true
+} // WinOS lacks currently required utmp support
+
+const the_executable = if supported_platform {
+	testing.prepare_executable(util)
+} else {
+	''
+}
+
+const cmd = testing.new_paired_command(util, the_executable)
 
 fn test_help_and_version() {
+	if !supported_platform {
+		return
+	}
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_unknown_option() {
+	if !supported_platform {
+		return
+	}
 	testing.command_fails('${the_executable} -x')!
 }
 
 fn test_print_uptime() {
+	if !supported_platform {
+		return
+	}
 	assert cmd.same_results('')
 	// assert cmd.same_results('/var/log/wtmp') // SKIP ~ `uptime FILE` is not universally supported
 }

--- a/src/wc/wc_test.v
+++ b/src/wc/wc_test.v
@@ -3,9 +3,17 @@ import common.testing
 
 const eol = testing.output_eol()
 
-const executable_under_test = testing.prepare_executable('wc')
+const util = 'wc'
 
-const cmd = testing.new_paired_command('wc', executable_under_test)
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
+
+const executable_under_test = testing.prepare_executable(util)
+
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!

--- a/src/wc/wc_test.v
+++ b/src/wc/wc_test.v
@@ -1,6 +1,8 @@
 import os
 import common.testing
 
+const eol = testing.output_eol()
+
 const the_executable = testing.prepare_executable('wc')
 
 const cmd = testing.new_paired_command('wc', the_executable)
@@ -28,17 +30,17 @@ fn test_abcd() {
 fn test_default() {
 	res := os.execute('${the_executable} ${test_txt_path}')
 	assert res.exit_code == 0
-	assert res.output == ' 1  5 25 ${test_txt_path}\n'
+	assert res.output == ' 1  5 25 ${test_txt_path}${eol}'
 }
 
 fn test_max_line_length() {
 	res := os.execute('${the_executable} -L ${test_txt_path}')
 	assert res.exit_code == 0
-	assert res.output == '12 ${test_txt_path}\n'
+	assert res.output == '12 ${test_txt_path}${eol}'
 }
 
 fn test_char_count() {
 	res := os.execute('${the_executable} -m ${test_txt_path}')
 	assert res.exit_code == 0
-	assert res.output == '25 ${test_txt_path}\n'
+	assert res.output == '25 ${test_txt_path}${eol}'
 }

--- a/src/wc/wc_test.v
+++ b/src/wc/wc_test.v
@@ -3,9 +3,9 @@ import common.testing
 
 const eol = testing.output_eol()
 
-const the_executable = testing.prepare_executable('wc')
+const executable_under_test = testing.prepare_executable('wc')
 
-const cmd = testing.new_paired_command('wc', the_executable)
+const cmd = testing.new_paired_command('wc', executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!
@@ -22,25 +22,25 @@ fn testsuite_end() {
 }
 
 fn test_abcd() {
-	res := os.execute('${the_executable} abcd')
+	res := os.execute('${executable_under_test} abcd')
 	assert res.exit_code == 1
 	assert res.output.trim_space() == 'wc: abcd: No such file or directory'
 }
 
 fn test_default() {
-	res := os.execute('${the_executable} ${test_txt_path}')
+	res := os.execute('${executable_under_test} ${test_txt_path}')
 	assert res.exit_code == 0
 	assert res.output == ' 1  5 25 ${test_txt_path}${eol}'
 }
 
 fn test_max_line_length() {
-	res := os.execute('${the_executable} -L ${test_txt_path}')
+	res := os.execute('${executable_under_test} -L ${test_txt_path}')
 	assert res.exit_code == 0
 	assert res.output == '12 ${test_txt_path}${eol}'
 }
 
 fn test_char_count() {
-	res := os.execute('${the_executable} -m ${test_txt_path}')
+	res := os.execute('${executable_under_test} -m ${test_txt_path}')
 	assert res.exit_code == 0
 	assert res.output == '25 ${test_txt_path}${eol}'
 }

--- a/src/whoami/lib_default.c.v
+++ b/src/whoami/lib_default.c.v
@@ -1,0 +1,18 @@
+import os
+
+#include <pwd.h>
+
+struct C.passwd {
+	pw_name &char
+}
+
+fn C.getpwuid(uid int) &C.passwd
+
+fn whoami() !string {
+	uid := os.geteuid()
+	if uid == -1 {
+		return error('no user name')
+	}
+	pwd := C.getpwuid(uid)
+	return unsafe { cstring_to_vstring(pwd.pw_name) }
+}

--- a/src/whoami/lib_windows.c.v
+++ b/src/whoami/lib_windows.c.v
@@ -1,0 +1,9 @@
+import os
+
+fn whoami() !string {
+	username := os.loginname()
+	if username == '' {
+		return error('no user name')
+	}
+	return username
+}

--- a/src/whoami/whoami.v
+++ b/src/whoami/whoami.v
@@ -1,14 +1,6 @@
 import os
 import common
 
-#include <pwd.h>
-
-struct C.passwd {
-	pw_name &char
-}
-
-fn C.getpwuid(uid int) &C.passwd
-
 fn main() {
 	mut fp := common.flag_parser(os.args)
 	fp.application('whoami')
@@ -16,11 +8,6 @@ fn main() {
 	fp.description('Same as id -un.')
 	fp.limit_free_args_to_exactly(0)!
 	fp.remaining_parameters()
-	uid := os.geteuid()
-	if uid == -1 {
-		common.exit_with_error_message('whoami', 'no user name')
-	}
-	pwd := C.getpwuid(uid)
-	username := unsafe { cstring_to_vstring(pwd.pw_name) }
+	username := whoami() or { common.exit_with_error_message('whoami', err.msg()) }
 	println(username)
 }

--- a/src/whoami/whoami_test.v
+++ b/src/whoami/whoami_test.v
@@ -1,17 +1,38 @@
 import common.testing
 
-const the_executable = testing.prepare_executable('whoami')
+const util = 'whoami'
 
-const cmd = testing.new_paired_command('whoami', the_executable)
+const supported_platform = $if windows {
+	false
+} $else {
+	true
+} // WinOS lacks currently required utmp support
+
+const the_executable = if supported_platform {
+	testing.prepare_executable(util)
+} else {
+	''
+}
+
+const cmd = testing.new_paired_command(util, the_executable)
 
 fn test_help_and_version() {
+	if !supported_platform {
+		return
+	}
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_unknown_option() {
+	if !supported_platform {
+		return
+	}
 	testing.command_fails('${the_executable} -x')!
 }
 
 fn test_print_machine_arch() {
+	if !supported_platform {
+		return
+	}
 	assert cmd.same_results('')
 }

--- a/src/whoami/whoami_test.v
+++ b/src/whoami/whoami_test.v
@@ -1,7 +1,12 @@
 import common.testing
 
 const util = 'whoami'
-const platform_util = $if !windows { util } $else { "coreutils ${util}" }
+
+const platform_util = $if !windows {
+	util
+} $else {
+	'coreutils ${util}'
+}
 
 const executable_under_test = testing.prepare_executable(util)
 

--- a/src/whoami/whoami_test.v
+++ b/src/whoami/whoami_test.v
@@ -1,38 +1,20 @@
 import common.testing
 
 const util = 'whoami'
+const platform_util = $if !windows { util } $else { "coreutils ${util}" }
 
-const supported_platform = $if windows {
-	false
-} $else {
-	true
-} // WinOS lacks currently required utmp support
+const the_executable = testing.prepare_executable(util)
 
-const the_executable = if supported_platform {
-	testing.prepare_executable(util)
-} else {
-	''
-}
-
-const cmd = testing.new_paired_command(util, the_executable)
+const cmd = testing.new_paired_command(platform_util, the_executable)
 
 fn test_help_and_version() {
-	if !supported_platform {
-		return
-	}
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_unknown_option() {
-	if !supported_platform {
-		return
-	}
 	testing.command_fails('${the_executable} -x')!
 }
 
-fn test_print_machine_arch() {
-	if !supported_platform {
-		return
-	}
+fn test_display_username() {
 	assert cmd.same_results('')
 }

--- a/src/whoami/whoami_test.v
+++ b/src/whoami/whoami_test.v
@@ -3,16 +3,16 @@ import common.testing
 const util = 'whoami'
 const platform_util = $if !windows { util } $else { "coreutils ${util}" }
 
-const the_executable = testing.prepare_executable(util)
+const executable_under_test = testing.prepare_executable(util)
 
-const cmd = testing.new_paired_command(platform_util, the_executable)
+const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!
 }
 
 fn test_unknown_option() {
-	testing.command_fails('${the_executable} -x')!
+	testing.command_fails('${executable_under_test} -x')!
 }
 
 fn test_display_username() {


### PR DESCRIPTION
- fixes WinOS builds, improves build script portability
  - all utils not dependent on unix or utmp are now built with `v build.vsh`
- adds WinOS CI with build & testing; tests are compared to `uutils/coreutils` v0.0.17+ for all tested utils
- WinOS utils with failing tests were all repaired