### PR TITLE
Fix `[`

### DIFF
--- a/build.vsh
+++ b/build.vsh
@@ -6,7 +6,6 @@ const (
 	ignore_dirs = $if windows {
 		[
 			// avoid *nix-dependent utils
-			'[',
 			'nohup',
 			// avoid utmp-dependent utils (WinOS has no utmp support)
 			'uptime',

--- a/common/common.c.v
+++ b/common/common.c.v
@@ -21,7 +21,7 @@ fn init() {
 pub fn is_utf8() bool {
 	locale := unsafe { C.setlocale(C.LC_CTYPE, &char(0)).vstring().to_lower() }
 	return locale.contains_any_substr(['utf8', 'utf-8']) || $if windows {
-		(C.GetACP() == 65001) || (C.GetConsoleOutputCP() == 65001) || (C.GetOEMCP() == 65001)
+		C.GetACP() == 65001 || C.GetConsoleOutputCP() == 65001 || C.GetOEMCP() == 65001
 	} $else {
 		false
 	}

--- a/common/readutmp_nix.c.v
+++ b/common/readutmp_nix.c.v
@@ -60,10 +60,10 @@ pub fn is_user_process(u &C.utmpx) bool {
 
 fn desirable_utmp_entry(u &C.utmpx, options ReadUtmpOptions) bool {
 	user_proc := is_user_process(u)
-	if (options == ReadUtmpOptions.user_process) && !user_proc {
+	if options == ReadUtmpOptions.user_process && !user_proc {
 		return false
 	}
-	if (options == ReadUtmpOptions.check_pids) && user_proc && 0 < u.ut_pid
+	if options == ReadUtmpOptions.check_pids && user_proc && 0 < u.ut_pid
 		&& (C.kill(u.ut_pid, 0) < 0 && C.errno == C.ESRCH) {
 		return false
 	}

--- a/src/[/left_bracket.c.v
+++ b/src/[/left_bracket.c.v
@@ -232,14 +232,19 @@ fn test_unary(option byte, arg string) bool {
 			return os.is_file(arg)
 		}
 		`g` {
-			if !os.exists(arg) {
+			$if windows {
+				// group ID not supported for WinOS
 				return false
+			} $else {
+				if !os.exists(arg) {
+					return false
+				}
+				attr := C.stat{}
+				unsafe {
+					C.stat(&char(arg.str), &attr)
+				}
+				return attr.st_mode & os.s_isgid > 0
 			}
-			attr := C.stat{}
-			unsafe {
-				C.stat(&char(arg.str), &attr)
-			}
-			return attr.st_mode & os.s_isgid > 0
 		}
 		`h`, `L` {
 			return os.is_link(arg)
@@ -263,14 +268,19 @@ fn test_unary(option byte, arg string) bool {
 			return os.is_atty(arg.int()) == 1
 		}
 		`u` {
-			if !os.exists(arg) {
+			$if windows {
+				// user ID not supported for WinOS
 				return false
+			} $else {
+				if !os.exists(arg) {
+					return false
+				}
+				attr := C.stat{}
+				unsafe {
+					C.stat(&char(arg.str), &attr)
+				}
+				return attr.st_mode & os.s_isuid > 0
 			}
-			attr := C.stat{}
-			unsafe {
-				C.stat(&char(arg.str), &attr)
-			}
-			return attr.st_mode & os.s_isuid > 0
 		}
 		`w` {
 			return os.is_writable(arg)

--- a/src/rm/helper.v
+++ b/src/rm/helper.v
@@ -136,8 +136,8 @@ fn setup_rm_command(args []string) !(RmCommand, []string) {
 		int_type = Interactive.no
 	}
 
-	interactive := fp.bool('', `i`, false, 'interactive always') || (int_type == .yes)
-	less_int := fp.bool('', `I`, false, 'interactive once') || (int_type == .once)
+	interactive := fp.bool('', `i`, false, 'interactive always') || int_type == .yes
+	less_int := fp.bool('', `I`, false, 'interactive once') || int_type == .once
 
 	if help {
 		success_exit(fp.usage())

--- a/src/shuf/shuf_test.v
+++ b/src/shuf/shuf_test.v
@@ -9,18 +9,18 @@ const test_txt_path = os.join_path(testing.temp_folder, 'test.txt')
 
 fn test_echo() {
 	res := os.execute('${shuf} -e aa bb')
-	assert (res.output == 'aa${eol}bb${eol}') || (res.output == 'bb${eol}aa${eol}')
+	assert res.output == 'aa${eol}bb${eol}' || res.output == 'bb${eol}aa${eol}'
 }
 
 fn test_file() {
 	os.write_file(test_txt_path, 'hello\nworld!')!
 	res := os.execute('${shuf} ${test_txt_path}')
-	assert (res.output == 'hello${eol}world!${eol}') || (res.output == 'world!${eol}hello${eol}')
+	assert res.output == 'hello${eol}world!${eol}' || res.output == 'world!${eol}hello${eol}'
 }
 
 fn test_zero_terminated_echo() {
 	res := os.execute('${shuf} -z -e aa bb')
-	assert (res.output == 'aabb') || (res.output == 'bbaa')
+	assert res.output == 'aabb' || res.output == 'bbaa'
 }
 
 fn test_zero_terminated_file() {


### PR DESCRIPTION
`test` and `[` should be identical and both WinOS compatible.

This updates the code, duplicating the working `test` to `[` and removes `[` from the build exclusion.

A `v fmt -w .` run was done to fix the failing CI format style test.