### PR TITLE
fix/[: (WinOS) duplicate `test` fix for utmp-dependent tests (-g and -u) 

### DIFF
--- a/build.vsh
+++ b/build.vsh
@@ -6,7 +6,6 @@ const (
 	ignore_dirs = $if windows {
 		[
 			// avoid *nix-dependent utils
-			'[',
 			'nohup',
 			// avoid utmp-dependent utils (WinOS has no utmp support)
 			'uptime',

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -142,6 +142,7 @@ const gnu_coreutils_installed = os.getenv('GNU_COREUTILS_INSTALLED').int() == 1
 // same_results/2 executes the given commands, and ensures that
 // their results are exactly the same, both for their exit codes,
 // and for their output.
+// note: use `v -d trace_same_results ...` to enable trace output
 pub fn same_results(cmd1 string, cmd2 string) bool {
 	mut cmd1_res := os.execute(cmd1)
 	mut cmd2_res := os.execute(cmd2)

--- a/src/[/left_bracket.c.v
+++ b/src/[/left_bracket.c.v
@@ -232,14 +232,19 @@ fn test_unary(option byte, arg string) bool {
 			return os.is_file(arg)
 		}
 		`g` {
-			if !os.exists(arg) {
+			$if windows {
+				// group ID not supported for WinOS
 				return false
+			} $else {
+				if !os.exists(arg) {
+					return false
+				}
+				attr := C.stat{}
+				unsafe {
+					C.stat(&char(arg.str), &attr)
+				}
+				return attr.st_mode & os.s_isgid > 0
 			}
-			attr := C.stat{}
-			unsafe {
-				C.stat(&char(arg.str), &attr)
-			}
-			return attr.st_mode & os.s_isgid > 0
 		}
 		`h`, `L` {
 			return os.is_link(arg)
@@ -263,14 +268,19 @@ fn test_unary(option byte, arg string) bool {
 			return os.is_atty(arg.int()) == 1
 		}
 		`u` {
-			if !os.exists(arg) {
+			$if windows {
+				// user ID not supported for WinOS
 				return false
+			} $else {
+				if !os.exists(arg) {
+					return false
+				}
+				attr := C.stat{}
+				unsafe {
+					C.stat(&char(arg.str), &attr)
+				}
+				return attr.st_mode & os.s_isuid > 0
 			}
-			attr := C.stat{}
-			unsafe {
-				C.stat(&char(arg.str), &attr)
-			}
-			return attr.st_mode & os.s_isuid > 0
 		}
 		`w` {
 			return os.is_writable(arg)


### PR DESCRIPTION
`[` will work for WinOS; it just needs the same code as `test`.
