### PR TITLE
fix: make wc conform to original behavior

### DIFF
--- a/src/wc/wc.v
+++ b/src/wc/wc.v
@@ -9,14 +9,14 @@ import arrays
 // https://github.com/ajeetdsouza/blog-wc-go
 
 const application_name = 'wc'
-const buffer_size        = 16 * 1024
-const new_line          = `\n`
-const space             = ` `
-const tab               = `\t`
-const carriage_return   = `\r`
-const vertical_tab      = `\v`
-const form_feed         = `\f`
-const file_list_sep    = '\x00'
+const buffer_size = 16 * 1024
+const new_line = `\n`
+const space = ` `
+const tab = `\t`
+const carriage_return = `\r`
+const vertical_tab = `\v`
+const form_feed = `\f`
+const file_list_sep = '\x00'
 
 struct FileChunk {
 mut:

--- a/src/wc/wc_test.v
+++ b/src/wc/wc_test.v
@@ -2,6 +2,7 @@ import os
 import common.testing
 
 const eol = testing.output_eol()
+const file_list_sep = '\x00'
 
 const util = 'wc'
 
@@ -15,40 +16,161 @@ const executable_under_test = testing.prepare_executable(util)
 
 const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
+const temp_dir = testing.temp_folder
+const file_list_path = os.join_path(temp_dir, 'files.txt')
+const test1_txt_path = os.join_path(temp_dir, 'test1.txt')
+const test2_txt_path = os.join_path(temp_dir, 'test2.txt')
+const test3_txt_path = os.join_path(temp_dir, 'test3.txt')
+const dummy = os.join_path(temp_dir, 'dummy')
+const long_over_16k = os.join_path(temp_dir, 'long_over_16k')
+const long_under_16k = os.join_path(temp_dir, 'long_under_16k')
+
+// todo add tests
+// - long line (>16k) count max line
+// - count max line at 16k bytes break
+// - test windows \r\n vs \n
+
 fn test_help_and_version() {
 	cmd.ensure_help_and_version_options_work()!
 }
 
-const test_txt_path = os.join_path(testing.temp_folder, 'test.txt')
-
 fn testsuite_begin() {
-	os.write_file(test_txt_path, 'Hello World!\nHow are you?')!
+	os.write_file(test1_txt_path, 'Hello World!\nHow are you?')!
+	os.write_file(test2_txt_path, 'twolinesonebreak\nbreakline')!
+	os.write_file(test3_txt_path, 'twolinestwobreaks\nbreakline\n')!
+	os.write_file(dummy, 'a'.repeat(50))!
+	os.write_file(long_over_16k, 'a'.repeat(16390))!
+	os.write_file(long_under_16k, 'a'.repeat(16383) + '\naaaaaaaaaaaaaaaaa')!
+	os.write_file(file_list_path, '${test1_txt_path}${file_list_sep}${test2_txt_path}${file_list_sep}${test3_txt_path}')!
 }
 
 fn testsuite_end() {
-	os.rm(test_txt_path)!
+	os.rm(test1_txt_path)!
+	os.rm(test2_txt_path)!
+	os.rm(test3_txt_path)!
+	os.rm(dummy)!
+	os.rm(long_over_16k)!
+	os.rm(long_under_16k)!
+	os.rm(file_list_path)!
 }
 
-fn test_abcd() {
+fn test_stdin() {
+	res := os.execute('cat ${test1_txt_path} | ${executable_under_test} -cmwlL')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '1  5 25 25 12'
+}
+
+fn test_stdin_file_list() {
+	res := os.execute('cat ${file_list_path} | ${executable_under_test} -cmwlL --files0-from=-')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '1 5 25 25 12 ${test1_txt_path}${eol}1 2 26 26 16 ${test2_txt_path}${eol}2 2 28 28 17 ${test3_txt_path}${eol}4 9 79 79 17 total'
+}
+
+fn test_file_file_list() {
+	res := os.execute('${executable_under_test} -cmwlL --files0-from=${file_list_path}')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '1  5 25 25 12 ${test1_txt_path}${eol} 1  2 26 26 16 ${test2_txt_path}${eol} 2  2 28 28 17 ${test3_txt_path}${eol} 4  9 79 79 17 total'
+}
+
+fn test_file_not_exist() {
 	res := os.execute('${executable_under_test} abcd')
+
 	assert res.exit_code == 1
 	assert res.output.trim_space() == 'wc: abcd: No such file or directory'
 }
 
 fn test_default() {
-	res := os.execute('${executable_under_test} ${test_txt_path}')
+	res := os.execute('${executable_under_test} ${test1_txt_path}')
+
 	assert res.exit_code == 0
-	assert res.output == ' 1  5 25 ${test_txt_path}${eol}'
+	assert res.output == ' 1  5 25 ${test1_txt_path}${eol}'
 }
 
 fn test_max_line_length() {
-	res := os.execute('${executable_under_test} -L ${test_txt_path}')
+	res := os.execute('${executable_under_test} -L ${test1_txt_path}')
+
 	assert res.exit_code == 0
-	assert res.output == '12 ${test_txt_path}${eol}'
+	assert res.output == '12 ${test1_txt_path}${eol}'
 }
 
 fn test_char_count() {
-	res := os.execute('${executable_under_test} -m ${test_txt_path}')
+	res := os.execute('${executable_under_test} -m ${test1_txt_path}')
+
 	assert res.exit_code == 0
-	assert res.output == '25 ${test_txt_path}${eol}'
+	assert res.output == '25 ${test1_txt_path}${eol}'
 }
+
+fn test_byte_count() {
+	res := os.execute('${executable_under_test} -c ${test1_txt_path}')
+
+	assert res.exit_code == 0
+	assert res.output == '25 ${test1_txt_path}${eol}'
+}
+
+fn test_lines_count() {
+	res := os.execute('${executable_under_test} -l ${test1_txt_path}')
+
+	assert res.exit_code == 0
+	assert res.output == '1 ${test1_txt_path}${eol}'
+}
+
+fn test_words_count() {
+	res := os.execute('${executable_under_test} -w ${test1_txt_path}')
+
+	assert res.exit_code == 0
+	assert res.output == '5 ${test1_txt_path}${eol}'
+}
+
+
+fn test_one_file_all_flags() {
+	res := os.execute('${executable_under_test} -cmwlL ${test1_txt_path}')
+
+	assert res.exit_code == 0
+	assert res.output == ' 1  5 25 25 12 ${test1_txt_path}${eol}'
+}
+
+fn test_several_files_all_flags() {
+	res := os.execute('${executable_under_test} -cmwlL ${test1_txt_path} ${test2_txt_path} ${test3_txt_path}')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '1  5 25 25 12 ${test1_txt_path}${eol} 1  2 26 26 16 ${test2_txt_path}${eol} 2  2 28 28 17 ${test3_txt_path}${eol} 4  9 79 79 17 total'
+}
+
+fn test_several_same_files_all_flags() {
+	res := os.execute('${executable_under_test} -cmwlL ${test1_txt_path} ${test1_txt_path} ${test1_txt_path}')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '1  5 25 25 12 ${test1_txt_path}${eol} 1  5 25 25 12 ${test1_txt_path}${eol} 1  5 25 25 12 ${test1_txt_path}${eol} 3 15 75 75 12 total'
+}
+
+fn test_no_newline_at_end() {
+	res := os.execute('${executable_under_test} -cmwlL ${dummy}')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '0  1 50 50 50 ${dummy}'
+}
+
+fn test_total_column_wider_than_single_file() {
+	res := os.execute('${executable_under_test} -cmwlL ${dummy} ${dummy} ${dummy}')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '0   1  50  50  50 ${dummy}${eol}  0   1  50  50  50 ${dummy}${eol}  0   1  50  50  50 ${dummy}${eol}  0   3 150 150  50 total'
+}
+
+fn test_over_16k_line_counts_max_line() {
+	res := os.execute('${executable_under_test} -cmwlL ${long_over_16k}')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '0     1 16390 16390 16390 ${long_over_16k}'
+}
+
+fn test_under_16k_line_counts_max_line() {
+	res := os.execute('${executable_under_test} -cmwlL ${long_under_16k}')
+
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '1     2 16401 16401 16383 ${long_under_16k}'
+}
+


### PR DESCRIPTION
WC was not replicating the original behavior, this PR fixes various stuff:

- add support for `--files0-from` option
- fix `--max-line-length` not working correctly on files with no trailing newline 
- fix `--max-line-length` not being able to handle lines over 16k chars long
- fix tab char count behavior
- fix stdin stream formatting
- fix total line formatting
- restore original repeated file behavior
- update annotation syntax to the most recent V standard
- update const definition syntax to the most recent V standard
- add tests for all updates