### PR TITLE
CoreUtil* structs to facilitate common behavior

### DIFF
--- a/common/common.v
+++ b/common/common.v
@@ -81,6 +81,6 @@ pub fn (app CoreutilInfo) make_flag_parser(args []string) &flag.FlagParser {
 	fp.footer(coreutils_footer())
 	fp.skip_executable()
 	fp.application(app.name)
-	fp.description(app.description)	
+	fp.description(app.description)
 	return fp
 }

--- a/common/common.v
+++ b/common/common.v
@@ -4,6 +4,19 @@ import flag
 
 pub const version = '0.0.1'
 
+pub struct CoreutilInfo {
+pub:
+	name        string
+	description string
+}
+
+pub struct CoreutilExitDetail {
+	message string
+mut:
+	return_code      int = 1
+	show_help_advice bool // defaults to false
+}
+
 // coreutils_version returns formatted coreutils tool version
 pub fn coreutils_version() string {
 	return '(V coreutils) ${common.version}'
@@ -45,4 +58,16 @@ pub fn exit_with_error_message(tool_name string, error string) {
 	}
 	eprintln("Try '${tool_name} --help' for more information.")
 	exit(1)
+}
+
+// A common way to exit with a custom error code (default: 1)
+// and the ability to direct the user to help (default: false)
+// to make it easier to match the output of the GNU coreutils
+@[noreturn]
+pub fn (app CoreutilInfo) quit(detail CoreutilExitDetail) {
+	eprintln('${app.name}: ${detail.message}')
+	if detail.show_help_advice {
+		eprintln("Try '${app.name} --help' for more information.")
+	}
+	exit(detail.return_code)
 }

--- a/common/common.v
+++ b/common/common.v
@@ -71,3 +71,16 @@ pub fn (app CoreutilInfo) quit(detail CoreutilExitDetail) {
 	}
 	exit(detail.return_code)
 }
+
+// flag_parser returns a flag.FlagParser, with the common
+// options already set, reducing the boilerplate code in
+// each individual utility.
+pub fn (app CoreutilInfo) make_flag_parser(args []string) &flag.FlagParser {
+	mut fp := flag.new_flag_parser(args)
+	fp.version(coreutils_version())
+	fp.footer(coreutils_footer())
+	fp.skip_executable()
+	fp.application(app.name)
+	fp.description(app.description)	
+	return fp
+}


### PR DESCRIPTION
I'd like to propose adding CoreUtil* structs to common to make it easier to provide consistent behavior across utils.

For example, this would enable:
```
const app = common.CoreutilInfo{
	name: 'tac'
	description: 'concatenate and print files in reverse'
}
...
mut fp := app.make_flag_parser(os.args)
...
file = os.open(fname) or {
    app.quit(message: "${fname}: read error")
}
app.quit(message: "Success!", return_code: 0)
app.quit(message: "Not sure how we can be here.", return_code: 127, show_help_advice: true)
```

If accepted, I am happy to do some refactoring to use it in the existing utilities.