### PR TITLE
Address testing errors discovered outside of CI

### DIFF
--- a/common/sums/sums.v
+++ b/common/sums/sums.v
@@ -26,7 +26,7 @@ pub fn sum(args []string, sum_name string, sum_type string, num_chars_in_sum int
 	warn := fp.bool('warn', `w`, false, '(only with -c) warn about improperly formatted checksum lines')
 
 	mut files := fp.finalize() or {
-		eprintln("${args[0]}: ${err.msg()}\nTry '${args[0]} --help' for more information.")
+		eprintln("${args[0]}: ${err.msg}\nTry '${args[0]} --help' for more information.")
 		exit(1)
 	}
 

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -1,6 +1,5 @@
 module testing
 
-import arrays
 import os
 import regex
 
@@ -147,24 +146,8 @@ const gnu_coreutils_installed = os.getenv('GNU_COREUTILS_INSTALLED').int() == 1
 pub fn same_results(cmd1 string, cmd2 string) bool {
 	cmd1_res := os.execute(cmd1)
 	cmd2_res := os.execute(cmd2)
-	
-	// If the util failed, it will return an error of this form
-	// <util>: something went wrong
-	// We strip out the <util>: part because it may include the path with
-	// which it was called (e.g., /usr/bin/<util>) and may therefore not match 
-	mut j1 := 0
-	mut j2 := 0
-	if cmd1_res.exit_code != 0 {
-		j1 = arrays.max([cmd1_res.output.index_after(':', 0), 0]) or { 0 }
-	}
-	if cmd2_res.exit_code != 0 {
-		j2 = arrays.max([cmd2_res.output.index_after(':', 0), 0]) or { 0 }
-	}
-	cmd1_output := cmd1_res.output[j1..]
-	cmd2_output := cmd2_res.output[j2..]
-	mut noutput1 := normalise(cmd1_output)
-	mut noutput2 := normalise(cmd2_output)
-
+	mut noutput1 := normalise(cmd1_res.output)
+	mut noutput2 := normalise(cmd2_res.output)
 	$if trace_same_results ? {
 		eprintln('------------------------------------')
 		eprintln('>> same_results cmd1: "${cmd1}"')
@@ -178,7 +161,7 @@ pub fn same_results(cmd1 string, cmd2 string) bool {
 	}
 	if testing.gnu_coreutils_installed {
 		// aim for 1:1 output compatibility:
-		return cmd1_res.exit_code == cmd2_res.exit_code && cmd1_output == cmd2_output
+		return cmd1_res.exit_code == cmd2_res.exit_code && cmd1_res.output == cmd2_res.output
 	}
 	// relax the strict matching for well known exceptions:
 	if cmd1.contains('coreutils') {

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -1,5 +1,6 @@
 module testing
 
+import arrays
 import os
 import regex
 
@@ -144,10 +145,26 @@ const gnu_coreutils_installed = os.getenv('GNU_COREUTILS_INSTALLED').int() == 1
 // and for their output.
 // note: use `v -d trace_same_results ...` to enable trace output
 pub fn same_results(cmd1 string, cmd2 string) bool {
-	mut cmd1_res := os.execute(cmd1)
-	mut cmd2_res := os.execute(cmd2)
-	mut noutput1 := normalise(cmd1_res.output)
-	mut noutput2 := normalise(cmd2_res.output)
+	cmd1_res := os.execute(cmd1)
+	cmd2_res := os.execute(cmd2)
+	
+	// If the util failed, it will return an error of this form
+	// <util>: something went wrong
+	// We strip out the <util>: part because it may include the path with
+	// which it was called (e.g., /usr/bin/<util>) and may therefore not match 
+	mut j1 := 0
+	mut j2 := 0
+	if cmd1_res.exit_code != 0 {
+		j1 = arrays.max([cmd1_res.output.index_after(':', 0), 0]) or { 0 }
+	}
+	if cmd2_res.exit_code != 0 {
+		j2 = arrays.max([cmd2_res.output.index_after(':', 0), 0]) or { 0 }
+	}
+	cmd1_output := cmd1_res.output[j1..]
+	cmd2_output := cmd2_res.output[j2..]
+	mut noutput1 := normalise(cmd1_output)
+	mut noutput2 := normalise(cmd2_output)
+
 	$if trace_same_results ? {
 		eprintln('------------------------------------')
 		eprintln('>> same_results cmd1: "${cmd1}"')
@@ -161,7 +178,7 @@ pub fn same_results(cmd1 string, cmd2 string) bool {
 	}
 	if testing.gnu_coreutils_installed {
 		// aim for 1:1 output compatibility:
-		return cmd1_res.exit_code == cmd2_res.exit_code && cmd1_res.output == cmd2_res.output
+		return cmd1_res.exit_code == cmd2_res.exit_code && cmd1_output == cmd2_output
 	}
 	// relax the strict matching for well known exceptions:
 	if cmd1.contains('coreutils') {

--- a/common/testing/testrig.c.v
+++ b/common/testing/testrig.c.v
@@ -1,45 +1,5 @@
 module testing
 
-import os
-
-pub fn prepare_rig(config TestRigConfig) TestRig {
-	call_util := $if !windows {
-		config.util
-	} $else {
-		'coreutils'
-	}
-
-	platform_util_path := os.find_abs_path_of_executable(call_util) or {
-		eprintln("ERROR: Local platform util '${call_util}' not found!")
-		assert false
-
-		// The compiler needs to know that this is going to end badly.
-		panic("Local platform util '${call_util}' not found!")
-	}
-
-	platform_util := if call_util == 'coreutils' {
-		'${call_util} ${config.util}'
-	} else {
-		call_util
-	}
-
-	exec_under_test := if config.is_supported_platform {
-		prepare_executable(config.util)
-	} else {
-		''
-	}
-	temp_dir := os.join_path(temp_folder, config.util)
-	os.mkdir(temp_dir) or { panic('Unable to make test directory: ${temp_dir}') }
-	os.chdir(temp_dir) or { panic('Unable to set working directory: ${temp_dir}') }
-	rig := TestRig{
-		util: config.util
-		platform_util: platform_util
-		platform_util_path: platform_util_path
-		cmd: new_paired_command(platform_util, exec_under_test)
-		executable_under_test: exec_under_test
-		temp_dir: temp_dir
-		is_supported_platform: config.is_supported_platform
-	}
+pub fn wire_clean_up_at_exit(rig TestRig) {
 	C.atexit(rig.clean_up)
-	return rig
 }

--- a/common/testing/testrig.c.v
+++ b/common/testing/testrig.c.v
@@ -21,11 +21,21 @@ pub:
 }
 
 pub fn prepare_rig(config TestRigConfig) TestRig {
-	platform_util := $if !windows {
+	local_util_name := $if !windows {
 		config.util
 	} $else {
-		'coreutils ${config.util}'
+		'coreutils'
 	}
+
+	local_util := os.find_abs_path_of_executable(local_util_name) or {
+		panic("Local platform util '${local_util_name}' not found!")
+	}
+	platform_util := if local_util_name == 'coreutils' {
+		'${local_util} ${config.util}'
+	} else {
+		local_util
+	}
+
 	exec_under_test := if config.is_supported_platform {
 		prepare_executable(config.util)
 	} else {

--- a/common/testing/testrig.c.v
+++ b/common/testing/testrig.c.v
@@ -10,6 +10,10 @@ pub fn prepare_rig(config TestRigConfig) TestRig {
 	}
 
 	platform_util_path := os.find_abs_path_of_executable(call_util) or {
+		eprintln("ERROR: Local platform util '${call_util}' not found!")
+		assert false
+
+		// The compiler needs to know that this is going to end badly.
 		panic("Local platform util '${call_util}' not found!")
 	}
 

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -75,6 +75,10 @@ pub fn (rig TestRig) clean_up() {
 }
 
 pub fn (rig TestRig) assert_platform_util() {
+	if !rig.is_supported_platform {
+		return
+	}
+
 	platform_ver := $if !windows {
 		os.execute('${rig.platform_util_path} --version')
 	} $else {

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -1,0 +1,123 @@
+module testing
+
+import os
+import regex
+
+// TestRig contains the relevant scaffolding for tests to avoid boilerplate in
+// the individual <util>_test.v files
+pub struct TestRig {
+pub:
+	util                  string
+	platform_util         string
+	platform_util_path    string
+	executable_under_test string
+	temp_dir              string
+	cmd                   CommandPair
+	is_supported_platform bool
+}
+
+pub struct TestRigConfig {
+pub:
+	util                  string
+	is_supported_platform bool = true
+}
+
+pub fn (rig TestRig) call_for_test(args string) os.Result {
+	res := os.execute('${rig.executable_under_test} ${args}')
+	assert res.exit_code == 0
+	return res
+}
+
+pub fn (rig TestRig) clean_up() {
+	if os.is_dir(rig.temp_dir) {
+		os.rmdir_all(rig.temp_dir) or {}
+	}
+}
+
+pub fn (rig TestRig) assert_same_results(args string) {
+	cmd1_res := os.execute('${rig.platform_util_path} ${args}')
+	cmd2_res := os.execute('${rig.executable_under_test} ${args}')
+	// If the name of the executable appears in the returned message, shorten it to the util
+	// name because the paths are different for GNU coreutil and v-coreutil
+	cmd1_output := cmd1_res.output.replace(rig.platform_util_path, rig.util)
+	cmd2_output := cmd2_res.output.replace(rig.executable_under_test, rig.util)
+	mut noutput1 := normalise(cmd1_output)
+	mut noutput2 := normalise(cmd2_output)
+
+	$if trace_same_results ? {
+		eprintln('------------------------------------')
+		eprintln('>> same_results cmd1: "${rig.platform_util_path} ${args}"')
+		eprintln('>> same_results cmd2: "${rig.executable_under_test} ${args}"')
+		eprintln('                cmd1_res.exit_code: ${cmd1_res.exit_code}')
+		eprintln('                cmd2_res.exit_code: ${cmd2_res.exit_code}')
+		eprintln('                cmd1_res.output.len: ${noutput1.len} | "${noutput1}"')
+		eprintln('                cmd2_res.output.len: ${noutput2.len} | "${noutput2}"')
+		eprintln('        (raw) > cmd1_res.output.len: ${cmd1_res.output.len} | "${cmd1_res.output}"')
+		eprintln('        (raw) > cmd2_res.output.len: ${cmd2_res.output.len} | "${cmd2_res.output}"')
+	}
+	if gnu_coreutils_installed {
+		// aim for 1:1 output compatibility:
+		assert cmd1_res.exit_code == cmd2_res.exit_code && cmd1_output == cmd2_output
+	}
+
+	match rig.util {
+		'coreutils' {
+			noutput1 = noutput1.replace("'coreutils ", "'")
+			// noutput2 = noutput2
+			$if trace_same_results ? {
+				eprintln('                 (coreutils) after1: ${noutput1.len} | "${noutput1}"')
+				eprintln('                 (coreutils) after2: ${noutput2.len} | "${noutput2}"')
+			}
+		}
+		'arch' {
+			// `arch` is not standardized and 'AMD64' is more commonly known as 'x86_64'
+			mut re := regex.regex_opt('[aA][mM][dD]64') or { panic(err) }
+			// noutput1 = noutput1
+			noutput2 = re.replace(noutput2, 'x86_64')
+			$if trace_same_results ? {
+				eprintln('                 (arch) after1: ${noutput1.len} | "${noutput1}"')
+				eprintln('                 (arch) after2: ${noutput2.len} | "${noutput2}"')
+			}
+		}
+		'printenv' {
+			assert cmd1_res.exit_code == cmd2_res.exit_code
+		}
+		'sleep' {
+			noutput1 = noutput1.replace(': invalid float literal', '')
+			// noutput2 = noutput2
+			$if trace_same_results ? {
+				eprintln('                (sleep) after1: ${noutput1.len} | "${noutput1}"')
+				eprintln('                (sleep) after2: ${noutput2.len} | "${noutput2}"')
+			}
+		}
+		'uname' {
+			// `uname` is not standardized and 'AMD64' is more commonly known as 'x86_64'
+			mut re := regex.regex_opt('[aA][mM][dD]64') or { panic(err) }
+			// noutput1 = noutput1
+			noutput2 = re.replace(noutput2, 'x86_64')
+			$if trace_same_results ? {
+				eprintln('                 (arch) after1: ${noutput1.len} | "${noutput1}"')
+				eprintln('                 (arch) after2: ${noutput2.len} | "${noutput2}"')
+			}
+		}
+		'uptime' {
+			noutput1 = cmd1_res.output.all_after('load average:')
+			noutput2 = cmd2_res.output.all_after('load average:')
+			$if trace_same_results ? {
+				eprintln('               (uptime) after1: ${noutput1.len} | "${noutput1}"')
+				eprintln('               (uptime) after2: ${noutput2.len} | "${noutput2}"')
+			}
+		}
+		else {
+			// in all other cases, compare the normalised output (less strict):
+		}
+	}
+	assert cmd1_res.exit_code == cmd2_res.exit_code && noutput1 == noutput2
+}
+
+pub fn (rig TestRig) assert_help_and_version_options_work() {
+	// For now, assume that the original has --version and --help
+	// and that they already work correctly.
+	assert os.execute('${rig.executable_under_test} --version').exit_code == 0
+	assert os.execute('${rig.executable_under_test} --help').exit_code == 0
+}

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -82,14 +82,24 @@ pub fn (rig TestRig) assert_platform_util() {
 	}
 	assert platform_ver.exit_code == 0
 	eprintln('Platform util version: ${platform_ver.output}')
-	ver := platform_ver.output.substr_with_check(0, rig.util.len + 12) or { platform_ver.output }
-	if rig.util != 'uptime' {
-		assert ver == '${rig.util} (GNU coreut' || ver == '${rig.util} (coreutils)'
-	} else {
-		// uptime was moved to procps-ng and may not be available in coreutils
 
-		assert
-			ver == 'uptime (GNU coreut' || ver == 'uptime (coreutils)' || ver == 'uptime from procps'
+	if platform_ver.output.len > rig.util.len {
+		assert platform_ver.output[..rig.util.len] == rig.util
+	}
+
+	// Windows does not clearly identify the GNU coreutils in the version string
+	$if !windows {
+		ver := platform_ver.output.substr_with_check(0, rig.util.len + 12) or {
+			platform_ver.output
+		}
+		if rig.util != 'uptime' {
+			assert ver == '${rig.util} (GNU coreut' || ver == '${rig.util} (coreutils)'
+		} else {
+			// uptime was moved to procps-ng and may not be available in coreutils
+
+			assert
+				ver == 'uptime (GNU coreut' || ver == 'uptime (coreutils)' || ver == 'uptime from procps'
+		}
 	}
 }
 

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -57,7 +57,8 @@ pub fn (rig TestRig) assert_same_results(args string) {
 	}
 	if gnu_coreutils_installed {
 		// aim for 1:1 output compatibility:
-		assert cmd1_res.exit_code == cmd2_res.exit_code && cmd1_output == cmd2_output
+		assert cmd1_res.exit_code == cmd2_res.exit_code 
+		assert cmd1_output == cmd2_output
 	}
 
 	match rig.util {
@@ -112,7 +113,8 @@ pub fn (rig TestRig) assert_same_results(args string) {
 			// in all other cases, compare the normalised output (less strict):
 		}
 	}
-	assert cmd1_res.exit_code == cmd2_res.exit_code && noutput1 == noutput2
+	assert cmd1_res.exit_code == cmd2_res.exit_code 
+	assert noutput1 == noutput2
 }
 
 pub fn (rig TestRig) assert_help_and_version_options_work() {

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -40,15 +40,15 @@ pub fn (rig TestRig) assert_same_results(args string) {
 	} $else {
 		os.execute('${rig.platform_util_path} ${rig.util} ${args}')
 	}
-	cmd1_output := $if !windows {
-		cmd1_res.output
-	} $else {
-		cmd1_res.output.replace(rig.platform_util_path, rig.util)
-	}
 	cmd2_res := os.execute('${rig.executable_under_test} ${args}')
+
 	// If the name of the executable appears in the returned message, shorten it to the util
 	// name because the paths are different for GNU coreutil and v-coreutil
-
+	cmd1_output := $if !windows {
+		cmd1_res.output.replace(rig.platform_util_path, rig.util)
+	} $else {
+		cmd1_res.output.replace('${rig.platform_util_path} ${rig.util}', '${rig.util}')
+	}
 	cmd2_output := cmd2_res.output.replace(rig.executable_under_test, rig.util)
 	mut noutput1 := normalise(cmd1_output)
 	mut noutput2 := normalise(cmd2_output)

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -57,7 +57,7 @@ pub fn (rig TestRig) assert_same_results(args string) {
 	}
 	if gnu_coreutils_installed {
 		// aim for 1:1 output compatibility:
-		assert cmd1_res.exit_code == cmd2_res.exit_code 
+		assert cmd1_res.exit_code == cmd2_res.exit_code
 		assert cmd1_output == cmd2_output
 	}
 
@@ -113,7 +113,7 @@ pub fn (rig TestRig) assert_same_results(args string) {
 			// in all other cases, compare the normalised output (less strict):
 		}
 	}
-	assert cmd1_res.exit_code == cmd2_res.exit_code 
+	assert cmd1_res.exit_code == cmd2_res.exit_code
 	assert noutput1 == noutput2
 }
 

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -40,10 +40,15 @@ pub fn (rig TestRig) assert_same_results(args string) {
 	} $else {
 		os.execute('${rig.platform_util_path} ${rig.util} ${args}')
 	}
+	cmd1_output := $if !windows {
+		cmd1_res.output
+	} $else {
+		cmd1_res.output.replace(rig.platform_util_path, rig.util)
+	}
 	cmd2_res := os.execute('${rig.executable_under_test} ${args}')
 	// If the name of the executable appears in the returned message, shorten it to the util
 	// name because the paths are different for GNU coreutil and v-coreutil
-	cmd1_output := cmd1_res.output.replace(rig.platform_util_path, rig.util)
+
 	cmd2_output := cmd2_res.output.replace(rig.executable_under_test, rig.util)
 	mut noutput1 := normalise(cmd1_output)
 	mut noutput2 := normalise(cmd2_output)

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -81,12 +81,14 @@ pub fn (rig TestRig) assert_platform_util() {
 		os.execute('${rig.platform_util_path} ${rig.util} --version')
 	}
 	assert platform_ver.exit_code == 0
-	ver := platform_ver.output[..rig.util.len + 16]
+	eprintln('Platform util version: ${platform_ver.output}')
+	ver := platform_ver.output.substr_with_check(0, rig.util.len + 12) or { platform_ver.output }
 	if rig.util != 'uptime' {
-		assert ver == '${rig.util} (GNU coreutils)'
+		assert ver == '${rig.util} (GNU coreut' || ver == '${rig.util} (coreutils)'
 	} else {
 		// uptime was moved to procps-ng and may not be available in coreutils
-		assert ver == 'uptime (GNU coreutils)' || ver == 'uptime from procps-ng '
+		assert
+			ver == 'uptime (GNU coreut' || ver == 'uptime (coreutils)' || ver == 'uptime from procps'
 	}
 }
 

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -35,7 +35,11 @@ pub fn (rig TestRig) clean_up() {
 }
 
 pub fn (rig TestRig) assert_same_results(args string) {
-	cmd1_res := os.execute('${rig.platform_util_path} ${args}')
+	cmd1_res := $if !windows {
+		os.execute('${rig.platform_util_path} ${args}')
+	} $else {
+		os.execute('${rig.platform_util_path} ${rig.util} ${args}')
+	}
 	cmd2_res := os.execute('${rig.executable_under_test} ${args}')
 	// If the name of the executable appears in the returned message, shorten it to the util
 	// name because the paths are different for GNU coreutil and v-coreutil

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -28,6 +28,45 @@ pub fn (rig TestRig) call_for_test(args string) os.Result {
 	return res
 }
 
+pub fn prepare_rig(config TestRigConfig) TestRig {
+	call_util := $if !windows {
+		config.util
+	} $else {
+		'coreutils'
+	}
+
+	platform_util_path := os.find_abs_path_of_executable(call_util) or {
+		eprintln("ERROR: Local platform util '${call_util}' not found!")
+		exit(1)
+	}
+
+	platform_util := if call_util == 'coreutils' {
+		'${call_util} ${config.util}'
+	} else {
+		call_util
+	}
+
+	exec_under_test := if config.is_supported_platform {
+		prepare_executable(config.util)
+	} else {
+		''
+	}
+	temp_dir := os.join_path(temp_folder, config.util)
+	os.mkdir(temp_dir) or { panic('Unable to make test directory: ${temp_dir}') }
+	os.chdir(temp_dir) or { panic('Unable to set working directory: ${temp_dir}') }
+	rig := TestRig{
+		util: config.util
+		platform_util: platform_util
+		platform_util_path: platform_util_path
+		cmd: new_paired_command(platform_util, exec_under_test)
+		executable_under_test: exec_under_test
+		temp_dir: temp_dir
+		is_supported_platform: config.is_supported_platform
+	}
+	wire_clean_up_at_exit(rig)
+	return rig
+}
+
 pub fn (rig TestRig) clean_up() {
 	if os.is_dir(rig.temp_dir) {
 		os.rmdir_all(rig.temp_dir) or {}

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -91,6 +91,7 @@ pub fn (rig TestRig) assert_same_results(args string) {
 		}
 		'printenv' {
 			assert cmd1_res.exit_code == cmd2_res.exit_code
+			return
 		}
 		'sleep' {
 			noutput1 = noutput1.replace(': invalid float literal', '')

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -87,6 +87,7 @@ pub fn (rig TestRig) assert_platform_util() {
 		assert ver == '${rig.util} (GNU coreut' || ver == '${rig.util} (coreutils)'
 	} else {
 		// uptime was moved to procps-ng and may not be available in coreutils
+
 		assert
 			ver == 'uptime (GNU coreut' || ver == 'uptime (coreutils)' || ver == 'uptime from procps'
 	}

--- a/common/testing/testrig.v
+++ b/common/testing/testrig.v
@@ -201,7 +201,7 @@ pub fn (rig TestRig) assert_help_and_version_options_work() {
 	// and that they already work correctly.
 
 	ver := os.execute('${rig.executable_under_test} --version')
-	assert ver.output == '${rig.util} (V coreutils) ${common.version}\n'
+	assert ver.output.trim_space() == '${rig.util} (V coreutils) ${common.version}'
 	assert ver.exit_code == 0
 	assert os.execute('${rig.executable_under_test} --help').exit_code == 0
 }

--- a/src/arch/arch_test.v
+++ b/src/arch/arch_test.v
@@ -1,19 +1,21 @@
 import common.testing
 
 const rig = testing.prepare_rig(util: 'arch')
-const cmd = rig.cmd
-const executable_under_test = rig.executable_under_test
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
 
 fn test_help_and_version() {
 	rig.assert_help_and_version_options_work()
 }
 
 fn test_unknown_option() {
-	testing.command_fails('${executable_under_test} -x')!
+	testing.command_fails('${rig.executable_under_test} -x')!
 }
 
 fn test_redundant_argument() {
-	testing.command_fails('${executable_under_test} x')!
+	testing.command_fails('${rig.executable_under_test} x')!
 }
 
 fn test_print_machine_arch() {

--- a/src/arch/arch_test.v
+++ b/src/arch/arch_test.v
@@ -5,7 +5,7 @@ const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_unknown_option() {
@@ -17,5 +17,5 @@ fn test_redundant_argument() {
 }
 
 fn test_print_machine_arch() {
-	assert cmd.same_results('')
+	rig.assert_same_results('')
 }

--- a/src/base32/helper.v
+++ b/src/base32/helper.v
@@ -41,7 +41,7 @@ fn decode_and_output(file os.File, wrap int) {
 	mut i := u64(0)
 	for {
 		num := file.read_bytes_into(i, mut groups) or {
-			common.exit_with_error_message(name, err.msg())
+			common.exit_with_error_message(name, err.msg)
 		}
 		if num == 0 || (num == 1 && groups[0] == `\n`) {
 			break
@@ -49,7 +49,7 @@ fn decode_and_output(file os.File, wrap int) {
 			common.exit_with_error_message(name, invalid)
 		}
 		i += u64(num)
-		builder.write(get_blocks(groups)) or { common.exit_with_error_message(name, err.msg()) }
+		builder.write(get_blocks(groups)) or { common.exit_with_error_message(name, err.msg) }
 	}
 	print(builder.str())
 }
@@ -81,7 +81,7 @@ fn encode_and_output(file os.File, wrap int) {
 					0
 				}
 				else {
-					common.exit_with_error_message(name, err.msg())
+					common.exit_with_error_message(name, err.msg)
 				}
 			}
 		}
@@ -104,7 +104,7 @@ fn encode_and_output(file os.File, wrap int) {
 		}
 		groups := get_groups(block, u8(num_equal))
 		mut result := strings.new_builder(groups.len)
-		result.write(groups) or { common.exit_with_error_message(name, err.msg()) }
+		result.write(groups) or { common.exit_with_error_message(name, err.msg) }
 		print(result.str())
 	}
 	println('')
@@ -114,7 +114,7 @@ fn get_file(file_arg []string) os.File {
 	if file_arg.len == 0 || file_arg[0] == '-' {
 		return os.stdin()
 	} else {
-		return os.open(file_arg[0]) or { common.exit_with_error_message(name, err.msg()) }
+		return os.open(file_arg[0]) or { common.exit_with_error_message(name, err.msg) }
 	}
 }
 
@@ -136,7 +136,7 @@ fn run_base32(args []string) {
 	if version {
 		success_exit('${name} ${common.coreutils_version()}')
 	}
-	file_arg := fp.finalize() or { common.exit_with_error_message(name, err.msg()) }
+	file_arg := fp.finalize() or { common.exit_with_error_message(name, err.msg) }
 
 	if file_arg.len > 1 {
 		common.exit_with_error_message(name, 'only one file should be provided')

--- a/src/base64/base64_test.v
+++ b/src/base64/base64_test.v
@@ -6,7 +6,7 @@ const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_abcd() {

--- a/src/base64/base64_test.v
+++ b/src/base64/base64_test.v
@@ -2,8 +2,11 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'base64')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
 
 fn test_help_and_version() {
 	rig.assert_help_and_version_options_work()

--- a/src/cksum/cksum_test.v
+++ b/src/cksum/cksum_test.v
@@ -2,7 +2,6 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'cksum')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 const eol = testing.output_eol()
 const test1_txt_path = os.join_path(rig.temp_dir, 'test1.txt')
@@ -13,6 +12,7 @@ const long_over_16k = os.join_path(rig.temp_dir, 'long_over_16k')
 const long_under_16k = os.join_path(rig.temp_dir, 'long_under_16k')
 
 fn testsuite_begin() {
+	rig.assert_platform_util()
 	os.write_file(test1_txt_path, 'Hello World!\nHow are you?')!
 	os.write_file(test2_txt_path, 'a'.repeat(128 * 1024 + 5))!
 }

--- a/src/cksum/cksum_test.v
+++ b/src/cksum/cksum_test.v
@@ -23,7 +23,7 @@ fn testsuite_end() {
 }
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_stdin() {

--- a/src/cp/CpCommand.v
+++ b/src/cp/CpCommand.v
@@ -27,7 +27,7 @@ fn (c CpCommand) run(source string, dest string) {
 			eprintln(not_recursive(source))
 			return
 		}
-		os.cp(source, dest) or { error_exit(name, err.msg()) }
+		os.cp(source, dest) or { error_exit(name, err.msg) }
 	}
 }
 

--- a/src/cp/helper.v
+++ b/src/cp/helper.v
@@ -72,7 +72,7 @@ fn success_exit(messages ...string) {
 fn setup_cp_command(args []string) ?(CpCommand, []string, string) {
 	mut fp := common.flag_parser(args)
 	fp.application('cp')
-	fp.limit_free_args_to_at_least(1) or { common.exit_with_error_message(name, err.msg()) }
+	fp.limit_free_args_to_at_least(1) or { common.exit_with_error_message(name, err.msg) }
 
 	force := fp.bool('force', `f`, false, 'ignore interactive and no-clobber')
 	interactive := fp.bool('interactive', `i`, false, 'ask for each overwrite')
@@ -143,9 +143,7 @@ fn setup_cp_command(args []string) ?(CpCommand, []string, string) {
 }
 
 pub fn run_cp(args []string) {
-	cp, sources, dest := setup_cp_command(args) or {
-		common.exit_with_error_message(name, err.msg())
-	}
+	cp, sources, dest := setup_cp_command(args) or { common.exit_with_error_message(name, err.msg) }
 	if sources.len > 1 && !os.is_dir(dest) {
 		common.exit_with_error_message(name, target_not_dir(dest))
 	}

--- a/src/dirname/dirname_test.v
+++ b/src/dirname/dirname_test.v
@@ -2,12 +2,15 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'dirname')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 const slash = $if !windows {
 	'\\'
 } $else {
 	'/'
+}
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
 }
 
 fn test_help_and_version() {

--- a/src/dirname/dirname_test.v
+++ b/src/dirname/dirname_test.v
@@ -11,7 +11,7 @@ const slash = $if !windows {
 }
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn expected_result(input string, output string) {

--- a/src/expand/expand.v
+++ b/src/expand/expand.v
@@ -32,7 +32,7 @@ fn process_stream(stream File, initial bool, tabs int) {
 	mut line := ''
 	for {
 		n := stream.read_bytes_into_newline(mut buf) or {
-			eprintln('${name}: ${err.msg()}')
+			eprintln('${name}: ${err.msg}')
 			0
 		}
 		if n <= 0 {
@@ -76,7 +76,7 @@ fn main() {
 				streams << os.stdin()
 			} else {
 				streams << os.open(path) or {
-					eprintln('${name}: ${err.msg()}')
+					eprintln('${name}: ${err.msg}')
 					exit(1)
 				}
 			}

--- a/src/expand/expand_test.v
+++ b/src/expand/expand_test.v
@@ -20,7 +20,7 @@ fn testsuite_end() {
 }
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_non_existent_file() {

--- a/src/expand/expand_test.v
+++ b/src/expand/expand_test.v
@@ -2,7 +2,6 @@ import os
 import common.testing
 
 const rig = testing.prepare_rig(util: 'expand')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 const eol = testing.output_eol()
 const test_txt_path = os.join_path(rig.temp_dir, 'test.txt')

--- a/src/expr/expr.v
+++ b/src/expr/expr.v
@@ -8,9 +8,7 @@ import common
 
 const appname = 'expr'
 
-const version = 'v0.0.1'
-
-const usage = '${appname} ${version}
+const usage = '${appname} ${common.version}
 ----------------------------------------------
 Usage: expr EXPRESSION
    or: expr OPTION
@@ -48,7 +46,7 @@ fn main() {
 					exit(0)
 				}
 				'--version' {
-					println('${appname} ${version}')
+					println('${appname} (V coreutils) ${common.version}')
 					exit(0)
 				}
 				else {}

--- a/src/expr/expr.v
+++ b/src/expr/expr.v
@@ -350,7 +350,7 @@ fn (v Value) str() string {
 
 fn (v Value) i64() i64 {
 	match v {
-		string { return strconv.parse_int(v, 0, 64) or { my_panic(err.msg(), 2) } }
+		string { return strconv.parse_int(v, 0, 64) or { my_panic(err.msg, 2) } }
 		i64 { return v }
 	}
 }

--- a/src/expr/expr_test.v
+++ b/src/expr/expr_test.v
@@ -5,10 +5,6 @@ import os
 const rig = testing.prepare_rig(util: 'expr')
 const cmd = rig.cmd
 
-fn test_help_and_version() {
-	rig.assert_help_and_version_options_work()
-}
-
 const tests = [
 	r'5 + 6',
 	r'5 - 6',
@@ -203,4 +199,12 @@ fn test_multi_byte_results() {
 	}
 	println(failed.join('\n'))
 	assert failed.len == 0
+}
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
+
+fn test_help_and_version() {
+	rig.assert_help_and_version_options_work()
 }

--- a/src/expr/expr_test.v
+++ b/src/expr/expr_test.v
@@ -6,7 +6,7 @@ const rig = testing.prepare_rig(util: 'expr')
 const cmd = rig.cmd
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 const tests = [

--- a/src/factor/factor.v
+++ b/src/factor/factor.v
@@ -52,7 +52,7 @@ fn main() {
 		for {
 			println(output_of(os.input_opt('') or { common.exit_on_errors(errors) }) or {
 				errors++
-				eprintln(err.msg())
+				eprintln(err.msg)
 				continue
 			})
 		}
@@ -60,7 +60,7 @@ fn main() {
 		for arg in args {
 			println(output_of(arg) or {
 				errors++
-				eprintln(err.msg())
+				eprintln(err.msg)
 				continue
 			})
 		}

--- a/src/factor/factor_test.v
+++ b/src/factor/factor_test.v
@@ -2,8 +2,11 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'factor')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
 
 fn test_help_and_version() {
 	rig.assert_help_and_version_options_work()

--- a/src/factor/factor_test.v
+++ b/src/factor/factor_test.v
@@ -6,7 +6,7 @@ const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_abcd() {

--- a/src/fold/fold.v
+++ b/src/fold/fold.v
@@ -142,7 +142,7 @@ fn (c FoldCommand) run(mut files []InputFile) {
 	mut open_fails_num := 0
 	for mut file in files {
 		file.open() or {
-			eprintln('${name}: ${err.msg()}')
+			eprintln('${name}: ${err.msg}')
 			open_fails_num++
 			continue
 		}
@@ -225,7 +225,7 @@ fn run_fold(args []string) {
 		success_exit('${name} ${common.coreutils_version()}')
 	}
 
-	file_args := fp.finalize() or { common.exit_with_error_message(name, err.msg()) }
+	file_args := fp.finalize() or { common.exit_with_error_message(name, err.msg) }
 
 	cmd := FoldCommand{
 		max_col_width: width

--- a/src/fold/fold_test.v
+++ b/src/fold/fold_test.v
@@ -7,6 +7,7 @@ const eol = testing.output_eol()
 const test_txt_path = os.join_path(rig.temp_dir, 'test.txt')
 
 fn testsuite_begin() {
+	rig.assert_platform_util()
 	mut f := os.open_file(test_txt_path, 'wb')!
 	for l in testtxtcontent {
 		f.writeln('${l}') or {}

--- a/src/fold/fold_test.v
+++ b/src/fold/fold_test.v
@@ -2,7 +2,6 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'fold')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 const eol = testing.output_eol()
 const test_txt_path = os.join_path(rig.temp_dir, 'test.txt')
@@ -20,7 +19,7 @@ fn testsuite_end() {
 }
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_non_existent_file() {

--- a/src/head/head.v
+++ b/src/head/head.v
@@ -207,7 +207,7 @@ fn (c HeadCommand) run(mut files []InputFile) {
 	mut open_fails_num := 0
 	for i, mut file in files {
 		file.open() or {
-			eprintln('${name}: ${err.msg()}')
+			eprintln('${name}: ${err.msg}')
 			open_fails_num++
 			continue
 		}
@@ -318,7 +318,7 @@ fn setup_command(args []string) ?(HeadCommand, []InputFile) {
 		success_exit('${name} ${common.coreutils_version()}')
 	}
 
-	file_args := fp.finalize() or { common.exit_with_error_message(name, err.msg()) }
+	file_args := fp.finalize() or { common.exit_with_error_message(name, err.msg) }
 
 	return HeadCommand{
 		bytes_to_read: bytes
@@ -330,7 +330,7 @@ fn setup_command(args []string) ?(HeadCommand, []InputFile) {
 }
 
 fn run_head(args []string) {
-	head, mut files := setup_command(args) or { common.exit_with_error_message(name, err.msg()) }
+	head, mut files := setup_command(args) or { common.exit_with_error_message(name, err.msg) }
 
 	head.run(mut files)
 }

--- a/src/head/head_test.v
+++ b/src/head/head_test.v
@@ -8,6 +8,7 @@ const eol = testing.output_eol()
 const test_txt_path = os.join_path(rig.temp_dir, 'test.txt')
 
 fn testsuite_begin() {
+	rig.assert_platform_util()
 	mut f := os.open_file(test_txt_path, 'wb')!
 	for l in testtxtcontent {
 		f.writeln('${l}')!

--- a/src/head/head_test.v
+++ b/src/head/head_test.v
@@ -20,7 +20,7 @@ fn testsuite_end() {
 }
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_non_existent_file() {

--- a/src/ln/Linker.v
+++ b/src/ln/Linker.v
@@ -38,18 +38,18 @@ fn (ln Linker) link_to_dir() {
 fn (ln Linker) link(source_path string, target_path string) {
 	if os.exists(target_path) {
 		if ln.force {
-			os.rm(target_path) or { common.exit_with_error_message(name, err.msg()) }
+			os.rm(target_path) or { common.exit_with_error_message(name, err.msg) }
 		} else {
 			common.exit_with_error_message(name, '${target_path} already exists')
 		}
 	}
 	if ln.symbolic {
-		os.symlink(source_path, target_path) or { common.exit_with_error_message(name, err.msg()) }
+		os.symlink(source_path, target_path) or { common.exit_with_error_message(name, err.msg) }
 	} else {
 		if os.is_dir(source_path) {
 			common.exit_with_error_message(name, 'only symbolic links are supported for directories')
 		}
-		os.link(source_path, target_path) or { common.exit_with_error_message(name, err.msg()) }
+		os.link(source_path, target_path) or { common.exit_with_error_message(name, err.msg) }
 	}
 	println('${target_path} -> ${source_path}')
 }

--- a/src/ln/helper.v
+++ b/src/ln/helper.v
@@ -12,7 +12,7 @@ fn success_exit(messages ...string) {
 fn run_ln(args []string) {
 	mut fp := common.flag_parser(args)
 	fp.application(name)
-	fp.limit_free_args_to_at_least(2) or { common.exit_with_error_message(name, err.msg()) }
+	fp.limit_free_args_to_at_least(2) or { common.exit_with_error_message(name, err.msg) }
 
 	force := fp.bool('', `f`, false, 'Force existing destination pathnames to be removed to allow the link.')
 	follow_symbolic := fp.bool('', `L`, false, 'For each source_file operand that names a file of type symbolic link, create a (hard) link to the file referenced by the symbolic link.')
@@ -29,7 +29,7 @@ fn run_ln(args []string) {
 		success_exit('${name} ${common.coreutils_version()}')
 	}
 
-	files := fp.finalize() or { common.exit_with_error_message(name, err.msg()) }
+	files := fp.finalize() or { common.exit_with_error_message(name, err.msg) }
 
 	mut ln := Linker{
 		force: force

--- a/src/mkdir/mkdir.v
+++ b/src/mkdir/mkdir.v
@@ -26,7 +26,7 @@ fn mkdir_cmd(files []string, opts &Options) {
 		if opts.parent {
 			os.mkdir_all(f, mode: opts.mode) or {
 				num_fails++
-				eprintln('${name}: ${f}: ${err.msg()}')
+				eprintln('${name}: ${f}: ${err.msg}')
 				continue
 			}
 			announce_creation(f, opts.verbose)
@@ -81,7 +81,7 @@ fn run_mkdir(args []string) {
 		success_exit('${name} ${common.coreutils_version()}')
 	}
 
-	file_args := fp.finalize() or { common.exit_with_error_message(name, err.msg()) }
+	file_args := fp.finalize() or { common.exit_with_error_message(name, err.msg) }
 	if file_args.len == 0 {
 		eprintln('${name}: missing operand')
 		eprintln("Try '${name} --help' for more information")

--- a/src/mkdir/mkdir_test.v
+++ b/src/mkdir/mkdir_test.v
@@ -14,6 +14,7 @@ const eol = testing.output_eol()
 const tfolder = os.join_path(os.temp_dir(), 'coreutils', 'mkdir_test')
 
 fn testsuite_begin() {
+	rig.assert_platform_util()
 	os.chdir(testing.temp_folder)!
 	eprintln('testsuite_begin, tfolder = ${tfolder}')
 	os.rmdir_all(tfolder) or {}

--- a/src/mkdir/mkdir_test.v
+++ b/src/mkdir/mkdir_test.v
@@ -1,6 +1,7 @@
 import os
 import common.testing
 
+const rig = testing.prepare_rig(util: 'mkdir')
 const eol = testing.output_eol()
 
 // A lot of the following has been lifted directly from os_test.v in vlib,
@@ -42,7 +43,7 @@ const executable_under_test = testing.prepare_executable(util)
 const cmd = testing.new_paired_command(platform_util, executable_under_test)
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_default_create_single_dir() {

--- a/src/mv/MvCommand.v
+++ b/src/mv/MvCommand.v
@@ -22,7 +22,7 @@ fn (m MvCommand) run(source string, dest string) {
 	if m.verbose || m.overwrite != .force {
 		m.move(source, dest)
 	} else {
-		os.mv(source, dest) or { error_exit(name, err.msg()) }
+		os.mv(source, dest) or { error_exit(name, err.msg) }
 	}
 }
 

--- a/src/mv/helper.v
+++ b/src/mv/helper.v
@@ -48,9 +48,7 @@ fn int_yes(prompt string) bool {
 }
 
 pub fn run_mv(args []string) {
-	mv, sources, dest := setup_mv_command(args) or {
-		common.exit_with_error_message(name, err.msg())
-	}
+	mv, sources, dest := setup_mv_command(args) or { common.exit_with_error_message(name, err.msg) }
 	if sources.len > 1 && !os.is_dir(dest) {
 		common.exit_with_error_message(name, target_not_dir(dest))
 	}
@@ -62,7 +60,7 @@ pub fn run_mv(args []string) {
 fn setup_mv_command(args []string) ?(MvCommand, []string, string) {
 	mut fp := common.flag_parser(args)
 	fp.application('mv')
-	fp.limit_free_args_to_at_least(1) or { common.exit_with_error_message(name, err.msg()) }
+	fp.limit_free_args_to_at_least(1) or { common.exit_with_error_message(name, err.msg) }
 
 	force := fp.bool('force', `f`, false, 'ignore interactive and no-clobber')
 	interactive := fp.bool('interactive', `i`, false, 'ask for each overwrite')

--- a/src/nl/nl.v
+++ b/src/nl/nl.v
@@ -152,7 +152,7 @@ fn open_stream(args_fn []string) []os.File {
 			// handle stdin like files
 			streams << os.stdin()
 		} else {
-			streams << os.open(fname) or { common.exit_with_error_message(app_name, err.msg()) }
+			streams << os.open(fname) or { common.exit_with_error_message(app_name, err.msg) }
 		}
 	}
 
@@ -238,11 +238,11 @@ fn args() ?(Settings, []string) {
 	// -b
 	b_style := fp.string('body-numbering', `b`, 't', 'Select the numbering style for lines in the body section (a:all, n:none, t:only no blank, pRE: match for the regular expression)')
 	settings.styles[Section.body] = get_style(b_style) or {
-		common.exit_with_error_message(app_name, err.msg())
+		common.exit_with_error_message(app_name, err.msg)
 	}
 	if settings.styles[Section.body] == .regex {
 		settings.res[Section.body] = get_style_regex(b_style) or {
-			common.exit_with_error_message(app_name, err.msg())
+			common.exit_with_error_message(app_name, err.msg)
 		}
 	}
 
@@ -267,22 +267,22 @@ fn args() ?(Settings, []string) {
 	// -f
 	f_style := fp.string('footer-numbering', `f`, 'n', 'Select the numbering style for lines in the footer section')
 	settings.styles[Section.footer] = get_style(f_style) or {
-		common.exit_with_error_message(app_name, err.msg())
+		common.exit_with_error_message(app_name, err.msg)
 	}
 	if settings.styles[Section.footer] == .regex {
 		settings.res[Section.footer] = get_style_regex(f_style) or {
-			common.exit_with_error_message(app_name, err.msg())
+			common.exit_with_error_message(app_name, err.msg)
 		}
 	}
 
 	// -h
 	h_style := fp.string('header-numbering', `h`, 'n', 'Select the numbering style for lines in the header section')
 	settings.styles[Section.header] = get_style(h_style) or {
-		common.exit_with_error_message(app_name, err.msg())
+		common.exit_with_error_message(app_name, err.msg)
 	}
 	if settings.styles[Section.header] == .regex {
 		settings.res[Section.header] = get_style_regex(h_style) or {
-			common.exit_with_error_message(app_name, err.msg())
+			common.exit_with_error_message(app_name, err.msg)
 		}
 	}
 
@@ -294,7 +294,7 @@ fn args() ?(Settings, []string) {
 
 	// -n
 	format := fp.string('number-format', `n`, 'rn', 'Select the line numbering format (ln:left-justified, rn:right-justified, rz:leading-zeros)')
-	settings.format = get_format(format) or { common.exit_with_error_message(app_name, err.msg()) }
+	settings.format = get_format(format) or { common.exit_with_error_message(app_name, err.msg) }
 
 	// -p
 	no_renumber := fp.bool('no-renumber', `p`, false, 'Do not reset the line number at the start of each logical page')
@@ -310,7 +310,7 @@ fn args() ?(Settings, []string) {
 	settings.width = fp.int('number-width', `w`, 6, 'Set number digits for line numbers')
 
 	// files
-	fnames = fp.finalize() or { common.exit_with_error_message(app_name, err.msg()) }
+	fnames = fp.finalize() or { common.exit_with_error_message(app_name, err.msg) }
 
 	return settings, fnames
 }

--- a/src/nohup/nohup.v
+++ b/src/nohup/nohup.v
@@ -61,12 +61,12 @@ fn main() {
 	}
 	if stdout_is_tty == 1 {
 		mut f := os.stdout()
-		open_nohup_out(mut f, true) or { common.exit_with_error_message(tool_name, err.msg()) }
+		open_nohup_out(mut f, true) or { common.exit_with_error_message(tool_name, err.msg) }
 	}
 	if os.is_atty(os.stderr().fd) == 1 {
 		if os.stdout().is_opened == false {
 			mut f := os.stderr()
-			open_nohup_out(mut f, false) or { common.exit_with_error_message(tool_name, err.msg()) }
+			open_nohup_out(mut f, false) or { common.exit_with_error_message(tool_name, err.msg) }
 		} else {
 			// couldn't find a v equilavent of this
 			C.dup2(os.stdout().fd, os.stderr().fd)

--- a/src/printenv/printenv_test.v
+++ b/src/printenv/printenv_test.v
@@ -1,8 +1,11 @@
 import common.testing
 
 const rig = testing.prepare_rig(util: 'printenv')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
 
 fn test_help_and_version() {
 	rig.assert_help_and_version_options_work()

--- a/src/printenv/printenv_test.v
+++ b/src/printenv/printenv_test.v
@@ -5,7 +5,7 @@ const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_unknown_option() {
@@ -13,28 +13,28 @@ fn test_unknown_option() {
 }
 
 fn test_print_all_default() {
-	assert cmd.same_results('')
+	rig.assert_same_results('')
 }
 
 fn test_print_all_nul_terminate() {
-	assert cmd.same_results('-0')
-	assert cmd.same_results('--null')
+	rig.assert_same_results('-0')
+	rig.assert_same_results('--null')
 }
 
 fn test_print_one_exist_env() {
-	assert cmd.same_results('LANGUAGE')
-	assert cmd.same_results('USER')
+	rig.assert_same_results('LANGUAGE')
+	rig.assert_same_results('USER')
 
-	assert cmd.same_results('-0 LANGUAGE')
-	assert cmd.same_results('LANGUAGE  -0')
+	rig.assert_same_results('-0 LANGUAGE')
+	rig.assert_same_results('LANGUAGE  -0')
 }
 
 fn test_print_not_exist_env() {
-	assert cmd.same_results('xxx')
-	assert cmd.same_results('-0 xxx')
+	rig.assert_same_results('xxx')
+	rig.assert_same_results('-0 xxx')
 }
 
 fn test_print_several_env_variables() {
-	assert cmd.same_results('LANGUAGE PWD')
-	assert cmd.same_results('-0 LANGUAGE LOGNAME')
+	rig.assert_same_results('LANGUAGE PWD')
+	rig.assert_same_results('-0 LANGUAGE LOGNAME')
 }

--- a/src/rm/RmCommand.v
+++ b/src/rm/RmCommand.v
@@ -44,7 +44,7 @@ fn (r RmCommand) rm_dir(path string) {
 			return
 		}
 
-		os.rmdir(path) or { eprintln(err.msg()) }
+		os.rmdir(path) or { eprintln(err.msg) }
 		return
 	}
 
@@ -123,7 +123,7 @@ fn (r RmCommand) rm_path(path string) {
 		return
 	}
 	if r.int_yes(prompt_file(path)) {
-		os.rm(path) or { error_message(name, err.msg()) }
+		os.rm(path) or { error_message(name, err.msg) }
 		if r.verbose {
 			println(rem(path))
 		}

--- a/src/rm/helper.v
+++ b/src/rm/helper.v
@@ -115,7 +115,7 @@ fn check_interactive(interactive string) !Interactive {
 fn setup_rm_command(args []string) !(RmCommand, []string) {
 	mut fp := common.flag_parser(args)
 	fp.application('rm')
-	fp.limit_free_args_to_at_least(1) or { common.exit_with_error_message(name, err.msg()) }
+	fp.limit_free_args_to_at_least(1) or { common.exit_with_error_message(name, err.msg) }
 
 	dir := fp.bool('dir', `d`, false, 'dir')
 	force := fp.bool('force', `f`, false, 'force')
@@ -155,7 +155,7 @@ fn setup_rm_command(args []string) !(RmCommand, []string) {
 // Entry point for all logic. Must be called from main
 pub fn run_rm(args []string) {
 	// Create command struct and accept flags and files
-	rm, files := setup_rm_command(args) or { common.exit_with_error_message(name, err.msg()) }
+	rm, files := setup_rm_command(args) or { common.exit_with_error_message(name, err.msg) }
 
 	// Take confirmation if necessary
 	if rm.confirm_int_once(files.len) {

--- a/src/rmdir/RmdirCommand.v
+++ b/src/rmdir/RmdirCommand.v
@@ -11,13 +11,13 @@ fn (r RmdirCommand) remove_dir(dir string) {
 	if r.verbose {
 		println("rmdir: removing directory, '${dir}'")
 	}
-	os.rmdir(dir) or { eprintln(err.msg()) }
+	os.rmdir(dir) or { eprintln(err.msg) }
 	if r.parents {
 		mut temp := if dir[dir.len - 1] == `/` { dir[0..dir.len - 1] } else { dir }
 		temp = os.dir(temp)
 		for temp != '' && temp != '/' && temp != '.' {
 			println(os.exists(temp))
-			os.rmdir(dir) or { eprintln('${temp}: ${err.msg()}') }
+			os.rmdir(dir) or { eprintln('${temp}: ${err.msg}') }
 			temp = os.dir(temp)
 		}
 	}

--- a/src/rmdir/helper.v
+++ b/src/rmdir/helper.v
@@ -36,7 +36,7 @@ fn setup_rmdir_command(args []string) !(RmdirCommand, []string) {
 }
 
 fn run_rmdir(args []string) {
-	rmdir, dirs := setup_rmdir_command(args) or { common.exit_with_error_message(name, err.msg()) }
+	rmdir, dirs := setup_rmdir_command(args) or { common.exit_with_error_message(name, err.msg) }
 	for dir in dirs {
 		rmdir.remove_dir(dir)
 	}

--- a/src/shuf/shuf.v
+++ b/src/shuf/shuf.v
@@ -100,7 +100,7 @@ fn shuffle_lines(lines []string, settings Settings) []string {
 		for i in 0 .. new_lines.len {
 			tmp := new_lines[i]
 			random := rand.intn(new_lines.len) or {
-				common.exit_with_error_message(app_name, err.msg())
+				common.exit_with_error_message(app_name, err.msg)
 			}
 			new_lines[i] = new_lines[random]
 			new_lines[random] = tmp
@@ -109,7 +109,7 @@ fn shuffle_lines(lines []string, settings Settings) []string {
 		for i in 0 .. new_lines.len {
 			tmp := new_lines[i]
 			random := rand.intn(new_lines.len) or {
-				common.exit_with_error_message(app_name, err.msg())
+				common.exit_with_error_message(app_name, err.msg)
 			}
 			new_lines[i] = new_lines[random]
 			new_lines[random] = tmp

--- a/src/shuf/shuf_test.v
+++ b/src/shuf/shuf_test.v
@@ -8,7 +8,7 @@ const eol = testing.output_eol()
 const test_txt_path = os.join_path(rig.temp_dir, 'test.txt')
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_echo() {

--- a/src/shuf/shuf_test.v
+++ b/src/shuf/shuf_test.v
@@ -2,10 +2,13 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'shuf')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 const eol = testing.output_eol()
 const test_txt_path = os.join_path(rig.temp_dir, 'test.txt')
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
 
 fn test_help_and_version() {
 	rig.assert_help_and_version_options_work()

--- a/src/sleep/sleep.v
+++ b/src/sleep/sleep.v
@@ -92,7 +92,7 @@ fn main() {
 		if s := apply_unit(n, unit) {
 			seconds += s
 		} else {
-			eprintln(err.msg())
+			eprintln(err.msg)
 			ok = false
 		}
 	}

--- a/src/sleep/sleep_test.v
+++ b/src/sleep/sleep_test.v
@@ -3,8 +3,11 @@ import os
 import time
 
 const rig = testing.prepare_rig(util: 'sleep')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
 
 fn test_help_and_version() {
 	rig.assert_help_and_version_options_work()

--- a/src/sleep/sleep_test.v
+++ b/src/sleep/sleep_test.v
@@ -7,7 +7,7 @@ const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_unknown_option() {
@@ -16,27 +16,27 @@ fn test_unknown_option() {
 }
 
 fn test_missing_arg() {
-	assert cmd.same_results('')
+	rig.assert_same_results('')
 }
 
 fn test_invalid_interval() {
-	assert cmd.same_results('-- -1')
-	assert cmd.same_results('1a')
-	assert cmd.same_results('1s0')
-	assert cmd.same_results('0.01 -- -1 0.01 1a 0.01 1s0')
+	rig.assert_same_results('-- -1')
+	rig.assert_same_results('1a')
+	rig.assert_same_results('1s0')
+	rig.assert_same_results('0.01 -- -1 0.01 1a 0.01 1s0')
 	res := os.execute('${executable_under_test} -1.7e+308')
 	assert res.exit_code == 1
 }
 
 fn test_valid_interval() {
-	assert cmd.same_results('0')
-	assert cmd.same_results('0s')
-	assert cmd.same_results('0.0')
-	assert cmd.same_results('0.0s')
-	assert cmd.same_results('0.1')
-	assert cmd.same_results('0.1s')
-	assert cmd.same_results('1')
-	assert cmd.same_results('1s')
+	rig.assert_same_results('0')
+	rig.assert_same_results('0s')
+	rig.assert_same_results('0.0')
+	rig.assert_same_results('0.0s')
+	rig.assert_same_results('0.1')
+	rig.assert_same_results('0.1s')
+	rig.assert_same_results('1')
+	rig.assert_same_results('1s')
 }
 
 fn test_interval() {

--- a/src/tac/tac_test.v
+++ b/src/tac/tac_test.v
@@ -5,7 +5,7 @@ const rig = testing.prepare_rig(util: 'tac')
 const cmd = rig.cmd
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 const tac_test_data = [
@@ -34,7 +34,7 @@ fn call_for_test(args string) os.Result {
 fn run_for_all(args string) {
 	for tf, path in tac_test_files {
 		eprintln('   >>>>>  Now testing: ${tf}  <<<<<   ')
-		assert cmd.same_results('${args} ${path}')
+		rig.assert_same_results('${args} ${path}')
 	}
 }
 
@@ -67,15 +67,15 @@ fn test_regex_sep_before() {
 }
 
 fn test_multiple() {
-	assert cmd.same_results('${tac_test_files['vanilla']} ${tac_test_files['seq']}')
+	rig.assert_same_results('${tac_test_files['vanilla']} ${tac_test_files['seq']}')
 }
 
 fn test_multiple_sep_before() {
-	assert cmd.same_results('-b ${tac_test_files['vanilla']} ${tac_test_files['seq']}')
+	rig.assert_same_results('-b ${tac_test_files['vanilla']} ${tac_test_files['seq']}')
 }
 
 fn test_file_does_not_exist() {
-	assert cmd.same_results('no_such_file.txt')
+	rig.assert_same_results('no_such_file.txt')
 }
 
 fn make_test_file(path string, sep string) ! {

--- a/src/tac/tac_test.v
+++ b/src/tac/tac_test.v
@@ -87,6 +87,7 @@ fn make_test_file(path string, sep string) ! {
 }
 
 fn testsuite_begin() {
+	rig.assert_platform_util()
 	os.write_file(tac_test_files['vanilla'], tac_test_data.join('\n'))!
 	os.write_file(tac_test_files['no_final_lf'], tac_test_data.join('\n') + '\n')!
 	make_test_file(tac_test_files['seq'], '\n')!

--- a/src/uname/uname_test.v
+++ b/src/uname/uname_test.v
@@ -5,7 +5,7 @@ const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_unknown_option() {
@@ -15,19 +15,19 @@ fn test_unknown_option() {
 }
 
 fn test_print_system_info() {
-	assert cmd.same_results('')
-	// assert cmd.same_results('--all')
-	assert cmd.same_results('--kernel-name')
-	assert cmd.same_results('--nodename')
-	assert cmd.same_results('--kernel-release')
-	assert cmd.same_results('--kernel-version')
-	assert cmd.same_results('--machine')
+	rig.assert_same_results('')
+	// rig.assert_same_results('--all')
+	rig.assert_same_results('--kernel-name')
+	rig.assert_same_results('--nodename')
+	rig.assert_same_results('--kernel-release')
+	rig.assert_same_results('--kernel-version')
+	rig.assert_same_results('--machine')
 	/*
-	assert cmd.same_results('--processor')
-	assert cmd.same_results('--hardware-platform')
-	assert cmd.same_results('--operating-system')*/
+	rig.assert_same_results('--processor')
+	rig.assert_same_results('--hardware-platform')
+	rig.assert_same_results('--operating-system')*/
 
-	// assert cmd.same_results('-a')
-	// assert cmd.same_results('-ma')
-	assert cmd.same_results('-vm -srn')
+	// rig.assert_same_results('-a')
+	// rig.assert_same_results('-ma')
+	rig.assert_same_results('-vm -srn')
 }

--- a/src/uname/uname_test.v
+++ b/src/uname/uname_test.v
@@ -4,6 +4,10 @@ const rig = testing.prepare_rig(util: 'uname')
 const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
+
 fn test_help_and_version() {
 	rig.assert_help_and_version_options_work()
 }

--- a/src/uniq/uniq_test.v
+++ b/src/uniq/uniq_test.v
@@ -4,6 +4,7 @@ import os
 const rig = testing.prepare_rig(util: 'uniq')
 
 fn testsuite_begin() {
+	rig.assert_platform_util()
 	os.write_file(posix_test_path_newline, posix_test_data.join('\n'))!
 	os.write_file(posix_test_path_zeroterm, posix_test_data.join('\0'))!
 	os.mkdir('foo')!

--- a/src/uniq/uniq_test.v
+++ b/src/uniq/uniq_test.v
@@ -2,7 +2,6 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'uniq')
-const cmd = rig.cmd
 
 fn testsuite_begin() {
 	os.write_file(posix_test_path_newline, posix_test_data.join('\n'))!

--- a/src/uniq/uniq_test.v
+++ b/src/uniq/uniq_test.v
@@ -32,43 +32,43 @@ const posix_test_path_zeroterm = 'posix_zt.txt'
 // investigate what gives.
 fn test_target_does_not_exist() {
 	$if !windows {
-		assert cmd.same_results('does_not_exist')
+		rig.assert_same_results('does_not_exist')
 	}
 }
 
 // TODO: This test does not run in all environments; to be investigated.
 // fn test_too_many_operands() {
 // 	$if !windows {
-// 		assert cmd.same_results('a b c')
+// 		rig.assert_same_results('a b c')
 // 	}
 // }
 
 fn test_source_is_directory() {
 	$if !windows {
-		assert cmd.same_results('foo')
+		rig.assert_same_results('foo')
 	}
 }
 
 fn test_target_is_directory() {
 	$if !windows {
-		assert cmd.same_results('posix_nl.txt foo')
+		rig.assert_same_results('posix_nl.txt foo')
 	}
 }
 
 fn test_posix_spec_case_1() {
-	assert cmd.same_results('-c -f 1 posix_nl.txt')
+	rig.assert_same_results('-c -f 1 posix_nl.txt')
 }
 
 fn test_posix_spec_case_2() {
-	assert cmd.same_results('-d -f 1 posix_nl.txt')
+	rig.assert_same_results('-d -f 1 posix_nl.txt')
 }
 
 fn test_posix_spec_case_3() {
-	assert cmd.same_results('-u -f 1 posix_nl.txt')
+	rig.assert_same_results('-u -f 1 posix_nl.txt')
 }
 
 fn test_posix_spec_case_4() {
-	assert cmd.same_results('-d -s 2 posix_nl.txt')
+	rig.assert_same_results('-d -s 2 posix_nl.txt')
 }
 
 fn test_posix_spec_case_1_zero_term() {
@@ -88,5 +88,5 @@ fn test_posix_spec_case_4_zero_term() {
 }
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }

--- a/src/unlink/unlink_test.v
+++ b/src/unlink/unlink_test.v
@@ -2,27 +2,26 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'unlink')
-const cmd = rig.cmd
 
 // TODO: The following tests fail in a Windows environment; need to
 // investigate what gives.
 fn test_target_does_not_exist() {
 	$if !windows {
-		assert cmd.same_results('does_not_exist')
+		rig.assert_same_results('does_not_exist')
 	}
 }
 
 // TODO: This test does not run in all environments; to be investigated.
 // fn test_too_many_operands() {
 // 	$if !windows {
-// 		assert cmd.same_results('a b c')
+// 		rig.assert_same_results('a b c')
 // 	}
 // }
 
 fn test_target_is_directory() {
 	$if !windows {
 		os.mkdir('foo')!
-		assert cmd.same_results('foo')
+		rig.assert_same_results('foo')
 		os.rmdir('foo')!
 	}
 }
@@ -37,5 +36,5 @@ fn test_target_does_exist() {
 }
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }

--- a/src/uptime/uptime.c.v
+++ b/src/uptime/uptime.c.v
@@ -130,12 +130,12 @@ fn main() {
 	match args.len {
 		0 {
 			uptime(common.utmp_file_charptr, .check_pids) or {
-				common.exit_with_error_message(fp.application_name, err.msg())
+				common.exit_with_error_message(fp.application_name, err.msg)
 			}
 		}
 		1 {
 			uptime(&char(args[0].str), .undefined) or {
-				common.exit_with_error_message(fp.application_name, err.msg())
+				common.exit_with_error_message(fp.application_name, err.msg)
 			}
 		}
 		else {}

--- a/src/uptime/uptime_test.v
+++ b/src/uptime/uptime_test.v
@@ -6,8 +6,11 @@ const supported_platform = $if windows {
 	true
 } // WinOS lacks currently required utmp support
 const rig = testing.prepare_rig(util: 'uptime', is_supported_platform: supported_platform)
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
 
 fn test_help_and_version() {
 	if !supported_platform {

--- a/src/uptime/uptime_test.v
+++ b/src/uptime/uptime_test.v
@@ -13,7 +13,7 @@ fn test_help_and_version() {
 	if !supported_platform {
 		return
 	}
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_unknown_option() {
@@ -28,6 +28,6 @@ fn test_unknown_option() {
 // 	if !supported_platform {
 // 		return
 // 	}
-// 	assert cmd.same_results('')
-// 	// assert cmd.same_results('/var/log/wtmp') // SKIP ~ `uptime FILE` is not universally supported
+// 	rig.assert_same_results('')
+// 	// rig.assert_same_results('/var/log/wtmp') // SKIP ~ `uptime FILE` is not universally supported
 // }

--- a/src/wc/wc_test.v
+++ b/src/wc/wc_test.v
@@ -2,7 +2,6 @@ import common.testing
 import os
 
 const rig = testing.prepare_rig(util: 'wc')
-const cmd = rig.cmd
 const executable_under_test = rig.executable_under_test
 const eol = testing.output_eol()
 const file_list_sep = '\x00'
@@ -39,7 +38,7 @@ fn testsuite_end() {
 }
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_stdin() {

--- a/src/wc/wc_test.v
+++ b/src/wc/wc_test.v
@@ -17,6 +17,7 @@ const long_under_16k = os.join_path(rig.temp_dir, 'long_under_16k')
 // - long line (>16k) count max line
 
 fn testsuite_begin() {
+	rig.assert_platform_util()
 	os.chdir(testing.temp_folder)!
 	os.write_file(test1_txt_path, 'Hello World!\nHow are you?')!
 	os.write_file(test2_txt_path, 'twolinesonebreak\nbreakline')!

--- a/src/whoami/whoami.v
+++ b/src/whoami/whoami.v
@@ -8,6 +8,6 @@ fn main() {
 	fp.description('Same as id -un.')
 	fp.limit_free_args_to_exactly(0)!
 	fp.remaining_parameters()
-	username := whoami() or { common.exit_with_error_message('whoami', err.msg()) }
+	username := whoami() or { common.exit_with_error_message('whoami', err.msg) }
 	println(username)
 }

--- a/src/whoami/whoami_test.v
+++ b/src/whoami/whoami_test.v
@@ -4,7 +4,7 @@ const rig = testing.prepare_rig(util: 'whoami')
 const cmd = rig.cmd
 
 fn test_help_and_version() {
-	cmd.ensure_help_and_version_options_work()!
+	rig.assert_help_and_version_options_work()
 }
 
 fn test_unknown_option() {
@@ -12,5 +12,5 @@ fn test_unknown_option() {
 }
 
 fn test_display_username() {
-	assert cmd.same_results('')
+	rig.assert_same_results('')
 }

--- a/src/whoami/whoami_test.v
+++ b/src/whoami/whoami_test.v
@@ -1,7 +1,10 @@
 import common.testing
 
 const rig = testing.prepare_rig(util: 'whoami')
-const cmd = rig.cmd
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
 
 fn test_help_and_version() {
 	rig.assert_help_and_version_options_work()


### PR DESCRIPTION
Even though having passed CI, some tests failed on different local setups, for example due to absence of the comparable utility (like `arch`). TestRig now tests for the presence of the GNU coreutil.

The PR also addresses the issue of mismatched outputs when tools returns errors that include args[0], for example: 

```
sleep: invalid option -- 'x'
Try 'sleep --help' for more information.
```
which then is compared to
```
/usr/bin/sleep: invalid option -- 'x'
Try '/usr/bin/sleep --help' for more information.
```

It does so by moving same_results and version_and_help testing to the TestRig which has more context information to work with.

Last, but not least, in several utilities the returned error message has been changed to `err.msg` instead of `err.msg()` since the latter will append `; Code X` to the error message and make it not match the GNU version.

Future Work: There are still some individual test cases that rely on the CommandPair same_results(), these will be refactored in the future to remove duplicate code.