### PR TITLE
Temporary fix for CI error for V PR# 20739

### DIFF
--- a/src/[/left_bracket.c.v
+++ b/src/[/left_bracket.c.v
@@ -296,12 +296,21 @@ fn test_unary(option u8, arg string) bool {
 	my_panic('unexpected unary operator')
 }
 
-struct C.stat {
-	st_size  u64
+// Minimal stat struct as specified in
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html
+// TODO: Replace with os.stat() once it's in in v:main
+pub struct C.stat {
+	st_dev   u64
+	st_ino   u64
 	st_mode  u32
+	st_nlink u64
+	st_uid   u32
+	st_gid   u32
+	st_rdev  u64
+	st_size  u64
+	st_atime int
 	st_mtime int
-	st_dev   usize
-	st_ino   usize
+	st_ctime int
 }
 
 enum FileType {


### PR DESCRIPTION
The CI error (https://github.com/vlang/v/actions/runs/7804487884/job/21287244166?pr=20739) is due to a duplication of C.stat from the os library in the left bracket util. This PR updates the duplicated struct for now. 

This fix is temporary, once os.stat() is a part of V, the duplication will be removed and the os.stat() function used instead.