### PR TITLE
Add sync util

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Contributions are welcome!
 Please only contribute versions of the original utilities written in V.
 Contributions written in other languages will likely be rejected.
 
-## Completed (48/109)
+## Completed (51/109)
 
 |  Done   | Cmd       | Descripton                                       |
 | :-----: | --------- | ------------------------------------------------ |
@@ -128,7 +128,7 @@ Contributions written in other languages will likely be rejected.
 |         | stdbuf    | Run a command with modified I/O stream buffering |
 |         | stty      | Print or change terminal characteristics         |
 |         | sum       | Print checksum and block counts                  |
-|         | sync      | Synchronize cached writes to persistent storage  |
+| &check; | sync      | Synchronize cached writes to persistent storage  |
 | &check; | tac       | Concatenate and write files in reverse           |
 |         | tail      | Output the last part of files                    |
 |         | tee       | Redirect output to multiple files or processes   |
@@ -137,7 +137,7 @@ Contributions written in other languages will likely be rejected.
 |         | touch     | Change file timestamps                           |
 |         | tr        | Translate, squeeze, and/or delete characters     |
 | &check; | true      | Do nothing, successfully                         |
-|         | truncate  | Shrink or extend the size of a file              |
+| &check; | truncate  | Shrink or extend the size of a file              |
 |         | tsort     | Topological sort                                 |
 |         | tty       | Print file name of terminal on standard input    |
 | &check; | uname     | Print system information                         |

--- a/src/sync/sync.v
+++ b/src/sync/sync.v
@@ -1,0 +1,61 @@
+import common
+import os
+
+const app = common.CoreutilInfo{
+	name: 'sync'
+	description: 'Synchronize cached writes to persistent storage'
+}
+
+// TODO: Make a Windows version using C.FlushFileBuffers()
+
+// Settings for Utility: sync
+struct Settings {
+mut:
+	data         bool
+	file_system  bool
+	target_files []string
+}
+
+fn args() Settings {
+	mut fp := app.make_flag_parser(os.args)
+	mut st := Settings{}
+	st.data = fp.bool('data', `d`, false, 'sync only file data, no unneeded metadata')
+	st.file_system = fp.bool('file-system', `f`, false, 'sync the file systems that contain the files')
+	st.target_files = fp.remaining_parameters()
+	if st.data && st.file_system {
+		app.quit(message: 'cannot specify both --data and --file-system')
+	}
+	if st.target_files.len == 0 {
+		if st.data {
+			app.quit(message: '--data needs at least one argument')
+		}
+		st.target_files << '.'
+		st.file_system = true
+	}
+	return st
+}
+
+fn sync(settings Settings) {
+	for path in settings.target_files {
+		// open file read-only and non-blocking
+		// TODO: there is more sophisticated handling in the
+		// GNU coreutil version with O_WRONLY attempts
+		mut f := os.open_file(path, 'rn') or {
+			app.quit(message: "error opening '${path}': ${err.msg()}")
+		}
+		defer {
+			f.close()
+		}
+		if settings.data {
+			do_fdatasync(f.fd) or { app.quit(message: err.msg()) }
+		} else if settings.file_system {
+			do_sync(f.fd) or { app.quit(message: err.msg()) }
+		} else {
+			do_fsync(f.fd) or { app.quit(message: err.msg()) }
+		}
+	}
+}
+
+fn main() {
+	sync(args())
+}

--- a/src/sync/sync_default.c.v
+++ b/src/sync/sync_default.c.v
@@ -1,0 +1,11 @@
+fn do_sync(fd int) ! {
+	return error_with_code('syncfs not available on this platform', 127)
+}
+
+fn do_fsync(fd int) ! {
+	return error_with_code('fsync not available on this platform', 127)
+}
+
+fn do_fdatasync(fd int) ! {
+	return error_with_code('fdatasync not available on this platform', 127)
+}

--- a/src/sync/sync_nix.c.v
+++ b/src/sync/sync_nix.c.v
@@ -1,0 +1,26 @@
+#include <unistd.h>
+
+fn C.fsync(int) int
+fn C.fdatasync(int) int
+fn C.syncfs(int) int
+
+fn do_sync(fd int) ! {
+	res := C.syncfs(1)
+	if res != 0 {
+		error_with_code('syncfs failed', C.errno)
+	}
+}
+
+fn do_fsync(fd int) ! {
+	res := C.fsync(fd)
+	if res != 0 {
+		error_with_code('fsync failed', C.errno)
+	}
+}
+
+fn do_fdatasync(fd int) ! {
+	res := C.fdatasync(fd)
+	if res != 0 {
+		error_with_code('fdatasync failed', C.errno)
+	}
+}

--- a/src/sync/sync_test.v
+++ b/src/sync/sync_test.v
@@ -1,0 +1,21 @@
+import common.testing
+
+const rig = testing.prepare_rig(util: 'sync')
+
+fn testsuite_begin() {
+	rig.assert_platform_util()
+}
+
+fn test_help_and_version() {
+	rig.assert_help_and_version_options_work()
+}
+
+fn test_sync() {
+	$if !windows {
+		rig.assert_same_results('-d')
+		rig.assert_same_results('-d .')
+		rig.assert_same_results('-d no_such_file')
+		rig.assert_same_results('-df')
+		rig.assert_same_results('-f')
+	}
+}


### PR DESCRIPTION
Implements the sync util based on the GNU coreutils version.

Does not work for Windows at this time (since there's no unistd.h); a separate mechanism based on FlushFileBuffers() will need to be built.

README update includes count and check for truncate to simplify merge once truncate is merged as well.