### PR TITLE
Add Tail implementaiton

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ count below and mark it as done in this README.md. Thanks!
 GNU coreutils. They are not 100% compatiable. If you encounter different behaviors, 
 compare against the true GNU coreutils version on the Linux-based tests first.
 
-## Completed (58/109)
+## Completed (59/109)
 
 |  Done   | Cmd       | Descripton                                       |
 | :-----: | --------- | ------------------------------------------------ |
@@ -138,7 +138,7 @@ compare against the true GNU coreutils version on the Linux-based tests first.
 |         | sum       | Print checksum and block counts                  |
 | &check; | sync      | Synchronize cached writes to persistent storage  |
 | &check; | tac       | Concatenate and write files in reverse           |
-|         | tail      | Output the last part of files                    |
+| &check; | tail      | Output the last part of files                    |
 |         | tee       | Redirect output to multiple files or processes   |
 | &check; | test      | Check file types and compare values              |
 |         | timeout   | Run a command with a time limit                  |

--- a/src/fmt/fmt_test.v
+++ b/src/fmt/fmt_test.v
@@ -23,6 +23,18 @@ fn to_tmp_file(data []string) string {
 	return file
 }
 
+fn setup() (fn (s string), fn () []string) {
+	mut result := []string{}
+	mut result_ref := &result
+	out_fn := fn [mut result_ref] (s string) {
+		result_ref << s
+	}
+	result_fn := fn [mut result_ref] () []string {
+		return *result_ref
+	}
+	return out_fn, result_fn
+}
+
 fn test_basic_wrap() {
 	println(@METHOD)
 	input := [
@@ -31,7 +43,8 @@ fn test_basic_wrap() {
 		'Now is the time for all good men to come to the aid of their country.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-w', '30', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-w', '30', tmp], out_fn)
 	os.rm(tmp)!
 	// print_lines(output)
 	expected := [
@@ -43,7 +56,7 @@ fn test_basic_wrap() {
 		'men to come to the aid of',
 		'their country.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_narrow_to_formatted() {
@@ -66,7 +79,8 @@ fn test_narrow_to_formatted() {
 		'Adios amigo.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', tmp], out_fn)
 	os.rm(tmp)!
 	// print_lines(output)
 	expected := [
@@ -80,7 +94,7 @@ fn test_narrow_to_formatted() {
 		'',
 		'Much ado about nothing.  He he he.  Adios amigo.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_line_indents_denote_new_paragraph() {
@@ -93,7 +107,8 @@ fn test_line_indents_denote_new_paragraph() {
 		'multline paragraph.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-w', '35', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-w', '35', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'This is a single line paragraph',
@@ -104,7 +119,7 @@ fn test_line_indents_denote_new_paragraph() {
 		'comprise a simple multline',
 		'paragraph.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_numbered_list_no_options() {
@@ -118,7 +133,8 @@ fn test_numbered_list_no_options() {
 		'    4. Now is the time for all good men to come to the aid of their country.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', tmp], out_fn)
 	os.rm(tmp)!
 	// print_lines(output)
 	expected := [
@@ -130,7 +146,7 @@ fn test_numbered_list_no_options() {
 		'    of their country.  4. Now is the time for all good men to come to the',
 		'    aid of their country.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_numbered_list_w_40() {
@@ -144,7 +160,8 @@ fn test_numbered_list_w_40() {
 		'    4. Now is the time for all good men to come to the aid of their country.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-w', '40', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-w', '40', tmp], out_fn)
 	os.rm(tmp)!
 	// print_lines(output)
 	expected := [
@@ -159,7 +176,7 @@ fn test_numbered_list_w_40() {
 		'    4. Now is the time for all good men',
 		'    to come to the aid of their country.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_split_only() {
@@ -180,7 +197,8 @@ fn test_split_only() {
 		'fringilla ut, venenatis ut, neque.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-s', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-s', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Curabitur',
@@ -202,7 +220,7 @@ fn test_split_only() {
 		'lacinia. Morbi fringilla lacus quis arcu. Vestibulum sem quam, dapibus in,',
 		'fringilla ut, venenatis ut, neque.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_indents_no_blank_lines() {
@@ -217,7 +235,8 @@ fn test_indents_no_blank_lines() {
 		'Love never fails.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'Love is patient, love is kind. It does not envy,',
@@ -228,7 +247,7 @@ fn test_indents_no_blank_lines() {
 		' always trusts, always hopes, always perseveres.',
 		'Love never fails.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_prefix_str_option() {
@@ -243,7 +262,8 @@ fn test_prefix_str_option() {
 		'> Court front maids forty if aware their at. Chicken use are pressed removed.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-p', '> ', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-p', '> ', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'Prefix lines test',
@@ -257,7 +277,7 @@ fn test_prefix_str_option() {
 		'> opinions it pleasure of debating.  Court front maids forty if aware their',
 		'> at. Chicken use are pressed removed.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_uniform_spacing_option() {
@@ -267,22 +287,24 @@ fn test_uniform_spacing_option() {
 	]
 	tmp := to_tmp_file(input)
 	// non-uniform case
-	output1 := run_fmt(['fmt', tmp])
+	out_fn1, result_fn1 := setup()
+	run_fmt(['fmt', tmp], out_fn1)
 	expected1 := [
 		'venenatis pede. Quisque dui     dui, ultricies ut, facilisis   non,',
 		'pulvinar non. Duis         quis arcu a purus volutpat iaculis. Morbi id dui',
 		'in    diam ornare',
 	]
-	assert output1 == expected1
+	assert result_fn1() == expected1
 
 	// uniform spacing case
-	output2 := run_fmt(['fmt', '-u', tmp])
+	out_fn2, result_fn2 := setup()
+	run_fmt(['fmt', '-u', tmp], out_fn2)
 	os.rm(tmp)!
 	expected2 := [
 		'venenatis pede. Quisque dui dui, ultricies ut, facilisis non, pulvinar non.',
 		'Duis quis arcu a purus volutpat iaculis. Morbi id dui in diam ornare',
 	]
-	assert output2 == expected2
+	assert result_fn2() == expected2
 }
 
 fn test_uniform_spacing_with_prefix_and_width() {
@@ -297,7 +319,8 @@ fn test_uniform_spacing_with_prefix_and_width() {
 		'> Court front maids forty if aware their at. Chicken use are pressed removed.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-u', '-p', '> ', '-w', '30', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-u', '-p', '> ', '-w', '30', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'> Prefix lines test',
@@ -319,7 +342,7 @@ fn test_uniform_spacing_with_prefix_and_width() {
 		'> aware their at. Chicken use',
 		'> are pressed removed.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_crown_and_uniform_options() {
@@ -330,7 +353,8 @@ fn test_crown_and_uniform_options() {
 		'introduced on output.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-c', '-u', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-c', '-u', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'By default, blank lines, spaces between words, and indentation are',
@@ -338,7 +362,7 @@ fn test_crown_and_uniform_options() {
 		'    indentation are not joined; tabs are expanded on input and',
 		'introduced on output.',
 	]
-	assert expected == output
+	assert result_fn() == expected
 }
 
 fn test_tagged_and_width_options() {
@@ -349,7 +373,8 @@ fn test_tagged_and_width_options() {
 		'Now is the time for all good men to come to the aid of their country.',
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-t', '-w', '40', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-t', '-w', '40', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'Now is the time for all good men to come',
@@ -358,7 +383,7 @@ fn test_tagged_and_width_options() {
 		'Now is the time for all good men to come',
 		'    to the aid of their country.',
 	]
-	assert expected == output
+	assert result_fn() == expected
 }
 
 fn test_unicode_handling() {
@@ -367,7 +392,8 @@ fn test_unicode_handling() {
 		"I can do without ⑰ lobsters, you know. Come on!' So they ⼘≺↩⌝⚙⠃ couldn't get them out again. The Mock Turtle went on again:-- 'I didn't mean it!' Ⓡpleaded.",
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-w', '40', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-w', '40', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'I can do without ⑰ lobsters, you know.',
@@ -375,7 +401,7 @@ fn test_unicode_handling() {
 		'them out again. The Mock Turtle went on',
 		"again:-- 'I didn't mean it!' Ⓡpleaded.",
 	]
-	assert output == expected
+	assert result_fn() == expected
 }
 
 fn test_unicode__tab_handling() {
@@ -384,7 +410,8 @@ fn test_unicode__tab_handling() {
 		"I can do without ⑰ lobsters, \tyou know. Come on!' So they ⼘≺↩⌝⚙⠃ couldn't get them out again. The Mock Turtle went on again:-- 'I didn't mean it!' Ⓡpleaded.",
 	]
 	tmp := to_tmp_file(input)
-	output := run_fmt(['fmt', '-w', '40', tmp])
+	out_fn, result_fn := setup()
+	run_fmt(['fmt', '-w', '40', tmp], out_fn)
 	os.rm(tmp)!
 	expected := [
 		'I can do without ⑰ lobsters,    you',
@@ -393,5 +420,5 @@ fn test_unicode__tab_handling() {
 		"on again:-- 'I didn't mean it!'",
 		'Ⓡpleaded.',
 	]
-	assert output == expected
+	assert result_fn() == expected
 }

--- a/src/tail/cmd_line.v
+++ b/src/tail/cmd_line.v
@@ -1,0 +1,96 @@
+import common
+import flag
+
+struct Args {
+	bytes          i64
+	follow         bool
+	lines          i64
+	pid            string
+	quiet          bool
+	retry          bool
+	sleep_interval f64
+	verbose        bool
+	from_start     bool
+	delimiter      u8 = `\n`
+	files          []string
+}
+
+fn get_args(args []string) Args {
+	mut fp := flag.new_flag_parser(args)
+
+	fp.application(app_name)
+	fp.version(common.coreutils_version())
+	fp.skip_executable()
+	fp.description('
+		Print the last 10 lines of each FILE to standard output.
+		With more than one FILE, precede each with a header giving the file name.
+
+		With no FILE, or when FILE is -, read standard input.'.trim_indent())
+
+	eol := common.eol()
+	wrap := eol + flag.space
+
+	bytes_arg := fp.string('bytes', `c`, '-1',
+		'output the last NUM bytes; or use -c +<int> to output      ${wrap}' +
+		'starting with byte <int> of each file')
+
+	follow_arg := fp.bool('follow', `f`, false, 'output appended data as the file grows')
+	f_arg := fp.bool('', `F`, false, 'same as --follow=name --retry')
+
+	lines_arg := fp.string('lines', `n`, '10',
+		'output the last NUM lines, instead of the last 10; or us${wrap}' +
+		'-n +NUM to skip NUM-1 lines at the start')
+
+	pid_arg := fp.string('pid', ` `, '', 'with -f, terminate after process ID, PID dies')
+	quiet_arg := fp.bool('quiet', `q`, false, 'never output headers giving file names')
+	silent_arg := fp.bool('silent', ` `, false, 'same as --quiet')
+	retry_arg := fp.bool('retry', ` `, false, 'keep trying to open a file if it is inaccessible')
+
+	sleep_interval_arg := fp.float('sleep-interval', `s`, 1.0,
+		'with -f, sleep for approximately N seconds (default 1.0)${wrap}' +
+		'between iterations; with inotify and --pid=P, check${wrap}' +
+		'process P at least once every N seconds')
+
+	verbose_arg := fp.bool('verbose', `v`, false, 'always output headers giving file names')
+	zero_terminated_arg := fp.bool('zero-terminated', `z`, false, 'line delimiter is NUL, not newline')
+
+	fp.footer('
+
+		NUM may have a multiplier suffix: b 512, kB 1000, K 1024, MB
+		1000*1000, M 1024*1024, GB 1000*1000*1000, G 1024*1024*1024, and
+		so on for T, P, E, Z, Y, R, Q. Binary prefixes can be used, too:
+		KiB=K, MiB=M, and so on.
+
+		This implementation of TAIL follows files by name only. File
+		descriptors are not supported'.trim_indent())
+
+	fp.footer(common.coreutils_footer())
+	file_args := fp.finalize() or { exit_error(err.msg()) }
+	from_start := bytes_arg.starts_with('+') || lines_arg.starts_with('+')
+	delimiter := if zero_terminated_arg { `\0` } else { `\n` }
+
+	return Args{
+		bytes: string_to_i64(bytes_arg) or { exit_error(err.msg()) }
+		follow: follow_arg
+		lines: string_to_i64(lines_arg) or { exit_error(err.msg()) }
+		pid: pid_arg
+		quiet: quiet_arg || silent_arg
+		retry: f_arg || retry_arg
+		verbose: verbose_arg
+		sleep_interval: sleep_interval_arg
+		from_start: from_start
+		delimiter: delimiter
+		files: file_args
+	}
+}
+
+@[noreturn]
+fn exit_success(msg string) {
+	println(msg)
+	exit(0)
+}
+
+@[noreturn]
+fn exit_error(msg string) {
+	common.exit_with_error_message(app_name, msg)
+}

--- a/src/tail/cmd_line.v
+++ b/src/tail/cmd_line.v
@@ -71,7 +71,7 @@ fn get_args(args []string) Args {
 
 	return Args{
 		bytes: string_to_i64(bytes_arg) or { exit_error(err.msg()) }
-		follow: follow_arg
+		follow: follow_arg || f_arg
 		lines: string_to_i64(lines_arg) or { exit_error(err.msg()) }
 		pid: pid_arg
 		quiet: quiet_arg || silent_arg

--- a/src/tail/string_to_i64.v
+++ b/src/tail/string_to_i64.v
@@ -18,8 +18,8 @@ const terra = giga * kilo
 const terrabyte = gigabyte * kilobyte
 
 // **5
-const peta = mega * kilo
-const petabyte = megabyte * kilobyte
+const peta = terra * kilo
+const petabyte = terra * kilobyte
 
 // **6
 const exa = peta * kilo

--- a/src/tail/string_to_i64.v
+++ b/src/tail/string_to_i64.v
@@ -1,0 +1,99 @@
+// convert strings like 10K to i164
+
+const block = 512
+
+// **1
+const kilo = i64(1024)
+const kilobyte = i64(1000)
+
+// **2
+const mega = kilo * kilo
+const megabyte = kilobyte * kilobyte
+
+// **3
+const giga = mega * kilo
+const gigabyte = megabyte * kilobyte
+
+// **4
+const terra = giga * kilo
+const terrabyte = gigabyte * kilobyte
+
+// **5
+const peta = mega * kilo
+const petabyte = megabyte * kilobyte
+
+// **6
+const exa = peta * kilo
+const exabyte = peta * kilo
+
+// **7
+const zetta = exa * kilo
+const zettabyte = exabyte * kilobyte
+
+// **8
+const yotta = zetta * kilo
+const yottabyte = zettabyte * kilobyte
+
+// **9
+const ronna = yotta * kilo
+const ronnabyte = yottabyte * kilobyte
+
+// **10
+const quetta = ronna * kilo
+const quettabyte = ronnabyte * kilobyte
+
+fn string_to_i64(s string) ?i64 {
+	if s.len == 0 {
+		return none
+	}
+
+	mut index := 0
+	for index < s.len {
+		match true {
+			s[index].is_digit() {}
+			s[index] == `+` && index == 0 {}
+			s[index] == `-` && index == 0 {}
+			else { break }
+		}
+		index += 1
+	}
+
+	number := s[0..index].i64()
+	suffix := if index < s.len { s[index..] } else { 'c' }
+
+	println("${number}. ${suffix}")
+
+	multiplier := match suffix.to_lower() {
+		'b' { block }
+		'k' { kilo }
+		'kb', 'kib' { kilobyte }
+		'm' { mega }
+		'mb', 'mib' { megabyte }
+		'g' { giga }
+		'gb', 'gib' { gigabyte }
+		't' { terra }
+		'tb', 'tib' { terrabyte }
+		'p' { peta }
+		'pb', 'pib' { petabyte }
+		'e' { exa }
+		'eb', 'eib' { exabyte }
+		'z' { zetta }
+		'zb', 'zib' { zettabyte }
+		'y' { yotta }
+		'yb', 'yib' { yottabyte }
+		'r' { ronna }
+		'rb', 'rib' { ronnabyte }
+		'q' { quetta }
+		'qb', 'qib' { quettabyte }
+		// oddball formats found in __xstrtol source
+		'c' { 1 }
+		'w' { 2 }
+		else { return none }
+	}
+
+	result := number * multiplier
+	if result == 0 && number != 0 {
+		return none
+	}
+	return result
+}

--- a/src/tail/string_to_i64.v
+++ b/src/tail/string_to_i64.v
@@ -1,5 +1,5 @@
 // convert strings like 10K to i164
-const block = 512
+const block = i64(512)
 
 // **1
 const kilo = i64(1024)
@@ -89,6 +89,7 @@ fn string_to_i64(s string) ?i64 {
 	}
 
 	result := number * multiplier
+	//println('${number} * ${multiplier} = ${result}')
 	if result == 0 && number != 0 {
 		return none
 	}

--- a/src/tail/string_to_i64.v
+++ b/src/tail/string_to_i64.v
@@ -89,7 +89,6 @@ fn string_to_i64(s string) ?i64 {
 	}
 
 	result := number * multiplier
-	// println('${number} * ${multiplier} = ${result}')
 	if result == 0 && number != 0 {
 		return none
 	}

--- a/src/tail/string_to_i64.v
+++ b/src/tail/string_to_i64.v
@@ -89,7 +89,7 @@ fn string_to_i64(s string) ?i64 {
 	}
 
 	result := number * multiplier
-	//println('${number} * ${multiplier} = ${result}')
+	// println('${number} * ${multiplier} = ${result}')
 	if result == 0 && number != 0 {
 		return none
 	}

--- a/src/tail/string_to_i64.v
+++ b/src/tail/string_to_i64.v
@@ -29,18 +29,6 @@ const exabyte = peta * kilo
 const zetta = exa * kilo
 const zettabyte = exabyte * kilobyte
 
-// **8
-const yotta = zetta * kilo
-const yottabyte = zettabyte * kilobyte
-
-// **9
-const ronna = yotta * kilo
-const ronnabyte = yottabyte * kilobyte
-
-// **10
-const quetta = ronna * kilo
-const quettabyte = ronnabyte * kilobyte
-
 fn string_to_i64(s string) ?i64 {
 	if s.len == 0 {
 		return none
@@ -74,14 +62,6 @@ fn string_to_i64(s string) ?i64 {
 		'pb', 'pib' { petabyte }
 		'e' { exa }
 		'eb', 'eib' { exabyte }
-		'z' { zetta }
-		'zb', 'zib' { zettabyte }
-		'y' { yotta }
-		'yb', 'yib' { yottabyte }
-		'r' { ronna }
-		'rb', 'rib' { ronnabyte }
-		'q' { quetta }
-		'qb', 'qib' { quettabyte }
 		// oddball formats found in __xstrtol source
 		'c' { 1 }
 		'w' { 2 }

--- a/src/tail/string_to_i64.v
+++ b/src/tail/string_to_i64.v
@@ -1,5 +1,4 @@
 // convert strings like 10K to i164
-
 const block = 512
 
 // **1
@@ -60,8 +59,6 @@ fn string_to_i64(s string) ?i64 {
 
 	number := s[0..index].i64()
 	suffix := if index < s.len { s[index..] } else { 'c' }
-
-	println("${number}. ${suffix}")
 
 	multiplier := match suffix.to_lower() {
 		'b' { block }

--- a/src/tail/string_to_i64_test.v
+++ b/src/tail/string_to_i64_test.v
@@ -16,9 +16,29 @@ fn test_string_to_i64_conversions() {
 	assert string_to_i64('16MB')! == 16 * megabyte
 	assert string_to_i64('17mib')! == 17 * megabyte
 
-	// anything bigger overflows an i64
-	overflow := string_to_i64('18T') or { -1 }
-	assert overflow == -1
+	assert string_to_i64('18T')! == 18 * terra
+	assert string_to_i64('18TB')! == 18 * terrabyte
+	assert string_to_i64('18TiB')! == 18 * terrabyte
+
+	assert string_to_i64('10P')! == 10 * peta
+	assert string_to_i64('10PB')! == 10 * petabyte
+	assert string_to_i64('10PiB')! == 10 * petabyte
+
+	assert string_to_i64('5E')! == 5 * exa
+	assert string_to_i64('5EB')! == 5 * exabyte
+	assert string_to_i64('5EiB')! == 5 * exabyte
+
+	assert string_to_i64('5Z')! == 5 * zetta
+
+	assert string_to_i64('5Y')! == 5 * yotta
+	assert string_to_i64('5YB')! == 5 * yottabyte
+	assert string_to_i64('5YiB')! == 5 * yottabyte
+
+	overflow_r := string_to_i64('5R') or { -1 }
+	assert overflow_r == -1
+
+	overflow_q := string_to_i64('5Q') or { -1 }
+	assert overflow_q == -1
 
 	// invalid checks
 	t0 := string_to_i64('') or { -1 }

--- a/src/tail/string_to_i64_test.v
+++ b/src/tail/string_to_i64_test.v
@@ -28,12 +28,6 @@ fn test_string_to_i64_conversions() {
 	assert string_to_i64('5EB')! == 5 * exabyte
 	assert string_to_i64('5EiB')! == 5 * exabyte
 
-	assert string_to_i64('5Z')! == 5 * zetta
-
-	assert string_to_i64('5Y')! == 5 * yotta
-	assert string_to_i64('5YB')! == 5 * yottabyte
-	assert string_to_i64('5YiB')! == 5 * yottabyte
-
 	overflow_r := string_to_i64('5R') or { -1 }
 	assert overflow_r == -1
 

--- a/src/tail/string_to_i64_test.v
+++ b/src/tail/string_to_i64_test.v
@@ -1,0 +1,32 @@
+module main
+
+fn test_string_to_i64_conversions() {
+	assert string_to_i64('1')! == 1
+	assert string_to_i64('+1')! == 1
+	assert string_to_i64('-1')! == -1
+
+	assert string_to_i64('2b')! == 2 * block
+
+	assert string_to_i64('11k')! == 11 * kilo
+	assert string_to_i64('12K')! == 12 * kilo
+	assert string_to_i64('13KB')! == 13 * kilobyte
+	assert string_to_i64('14KiB')! == 14 * kilobyte
+
+	assert string_to_i64('15M')! == 15 * mega
+	assert string_to_i64('16MB')! == 16 * megabyte
+	assert string_to_i64('17mib')! == 17 * megabyte
+
+	// anything bigger overflows an i64
+	overflow := string_to_i64('18T') or { -1 }
+	assert overflow == -1
+
+	// invalid checks
+	t0 := string_to_i64('') or { -1 }
+	assert t0 == -1
+
+	t1 := string_to_i64('1x') or { -1 }
+	assert t1 == -1
+
+	t2 := string_to_i64('++1') or { -1 }
+	assert t2 == -1
+}

--- a/src/tail/tail.v
+++ b/src/tail/tail.v
@@ -19,20 +19,21 @@ fn tail(args Args) {
 
 fn tail_(args Args, out_fn fn (s string)) {
 	for i, file in args.files {
-		file_header(file, i == 0, args.files.len, out_fn)
+		file_header(file, i == 0, args, out_fn)
 		tail_file(file, args, out_fn)
 	}
 }
 
-fn file_header(file string, first bool, number_of_files int, out_fn fn (s string)) {
-	if number_of_files == 1 {
-		return
-	}
+fn file_header(file string, first bool, args Args, out_fn fn (s string)) {
 	if !first {
 		out_fn('')
 	}
-	out_fn('===> ${file} <===')
-	out_fn('')
+	if args.quiet {
+		return
+	}
+	if args.files.len > 1 || args.verbose {
+		out_fn('===> ${file} <===')
+	}
 }
 
 fn tail_file(file string, args Args, out_fn fn (s string)) {

--- a/src/tail/tail.v
+++ b/src/tail/tail.v
@@ -1,0 +1,81 @@
+// tail - output the last part of files
+import common
+import flag
+import os
+
+const app_name = 'tail'
+
+fn main() {
+	get_args(os.args)
+}
+
+fn get_args(args []string) {
+	mut fp := flag.new_flag_parser(args)
+
+	fp.application(app_name)
+	fp.version(common.coreutils_version())
+	fp.skip_executable()
+	fp.description('
+		Print the last 10 lines of each FILE to standard output.
+		With more than one FILE, precede each with a header giving the file name.
+
+		With no FILE, or when FILE is -, read standard input.'.trim_indent())
+
+	eol := common.eol()
+	wrap := eol + flag.space
+
+	fp.string('bytes', `c`, '',
+		'output the last NUM bytes; or use -c +<int> to output      ${wrap}' +
+		'starting with byte <int> of each file')
+	fp.string('follow', `f`, 'descriptor',
+		'output appended data as the file grows        ${wrap}' +
+		"an absent option argument means 'descriptor'")
+	fp.bool('', `F`, false, 'same as --follow=name --retry')
+	fp.string('lines', `n`, '10',
+		'output the last NUM lines, instead of the last 10; or us${wrap}' +
+		'-n +NUM to skip NUM-1 lines at the start')
+	fp.int('max-unchanged-stats', ` `, 5,
+		'with --follow=name, reopen a FILE which has not${wrap}' +
+		'changed size after N (default 5) iterations to see if it${wrap}' +
+		'has been unlinked or renamed (this is the usual case of${wrap}' +
+		'rotated log files); with inotify, this option is rarely usefule')
+	fp.string('pid', ` `, '', 'with -f, terminate after process ID, PID dies')
+	fp.bool('quiet', `q`, false, 'never output headers giving file names')
+	fp.bool('silent', ` `, false, 'same as --quiet')
+	fp.bool('retry', ` `, false, 'keep trying to open a file if it is inaccessible')
+	fp.float('sleep-interval', `s`, 1.0,
+		'with -f, sleep for approximately N seconds (default 1.0)${wrap}' +
+		'between iterations; with inotify and --pid=P, check${wrap}' +
+		'process P at least once every N seconds')
+	fp.bool('verbose', `v`, false, 'always output headers giving file names')
+	fp.bool('zero-terminated', `z`, false, 'line delimiter is NUL, not newline')
+
+	fp.footer("
+
+		NUM may have a multiplier suffix: b 512, kB 1000, K 1024, MB
+		1000*1000, M 1024*1024, GB 1000*1000*1000, G 1024*1024*1024, and
+		so on for T, P, E, Z, Y, R, Q.  Binary prefixes can be used, too:
+		KiB=K, MiB=M, and so on.
+
+		With --follow (-f), tail defaults to following the file
+		descriptor, which means that even if a tail'ed file is renamed,
+		tail will continue to track its end.  This default behavior is
+		not desirable when you really want to track the actual name of
+		the file, not the file descriptor (e.g., log rotation).  Use
+		--follow=name in that case.  That causes tail to track the named
+		file in a way that accommodates renaming, removal and creation.".trim_indent())
+
+	fp.footer(common.coreutils_footer())
+	fp.finalize() or { exit_error(err.msg()) }
+}
+
+@[noreturn]
+fn exit_success(msg string) {
+	println(msg)
+	exit(0)
+}
+
+@[noreturn]
+fn exit_error(msg string) {
+	common.exit_with_error_message(app_name, msg)
+}

--- a/src/tail/tail.v
+++ b/src/tail/tail.v
@@ -2,7 +2,6 @@
 import common
 import flag
 import os
-import strconv
 import v.mathutil
 
 const app_name = 'tail'
@@ -19,9 +18,21 @@ fn tail(args Args) {
 }
 
 fn tail_(args Args, out_fn fn (s string)) {
-	for file in args.files {
+	for i, file in args.files {
+		file_header(file, i == 0, args.files.len, out_fn)
 		tail_file(file, args, out_fn)
 	}
+}
+
+fn file_header(file string, first bool, number_of_files int, out_fn fn (s string)) {
+	if number_of_files == 1 {
+		return
+	}
+	if !first {
+		out_fn('')
+	}
+	out_fn('===> ${file} <===')
+	out_fn('')
 }
 
 fn tail_file(file string, args Args, out_fn fn (s string)) {
@@ -41,9 +52,9 @@ fn tail_lines(lines []string, args Args, out_fn fn (s string)) {
 }
 
 struct Args {
-	bytes               int
+	bytes               i64
 	follow              string
-	lines               int
+	lines               i64
 	max_unchanged_stats int
 	pid                 string
 	quiet               bool
@@ -99,24 +110,24 @@ fn get_args(args []string) Args {
 
 		NUM may have a multiplier suffix: b 512, kB 1000, K 1024, MB
 		1000*1000, M 1024*1024, GB 1000*1000*1000, G 1024*1024*1024, and
-		so on for T, P, E, Z, Y, R, Q.  Binary prefixes can be used, too:
+		so on for T, P, E, Z, Y, R, Q. Binary prefixes can be used, too:
 		KiB=K, MiB=M, and so on.
 
 		With --follow (-f), tail defaults to following the file
 		descriptor, which means that even if a tail'ed file is renamed,
-		tail will continue to track its end.  This default behavior is
+		tail will continue to track its end. This default behavior is
 		not desirable when you really want to track the actual name of
-		the file, not the file descriptor (e.g., log rotation).  Use
-		--follow=name in that case.  That causes tail to track the named
+		the file, not the file descriptor (e.g., log rotation). Use
+		--follow=name in that case. That causes tail to track the named
 		file in a way that accommodates renaming, removal and creation.".trim_indent())
 
 	fp.footer(common.coreutils_footer())
 	file_args := fp.finalize() or { exit_error(err.msg()) }
 
 	return Args{
-		bytes: strconv.atoi(bytes_arg) or { exit_error(err.msg()) }
+		bytes: string_to_i64(bytes_arg) or { exit_error(err.msg()) }
 		follow: if f_arg { 'descriptor' } else { follow_arg }
-		lines: strconv.atoi(lines_arg) or { exit_error(err.msg()) }
+		lines: string_to_i64(lines_arg) or { exit_error(err.msg()) }
 		max_unchanged_stats: max_unchanged_stats_arg
 		pid: pid_arg
 		quiet: quiet_arg || silent_arg

--- a/src/tail/tail.v
+++ b/src/tail/tail.v
@@ -82,6 +82,7 @@ fn tail_file(file FileInfo, args Args, out_fn fn (string)) {
 	defer { f.close() }
 	
 	buf_size := i64(4096)
+	mut buf := []u8{len: int(buf_size)}
 	mut count := 0
 
 	f.seek(0, .end) or { exit_error(err.msg()) }
@@ -93,7 +94,7 @@ fn tail_file(file FileInfo, args Args, out_fn fn (string)) {
 
 		loop1: for pos <= end {
 			len := mathutil.min(end - pos, buf_size)
-			buf := f.read_bytes_at(int(len), u64(pos))
+			f.read_bytes_into(u64(pos), mut buf) or { exit_error(err.msg()) }
 
 			for i := 0; i < len; i += 1 {
 				if buf[i] == `\n` {
@@ -115,7 +116,7 @@ fn tail_file(file FileInfo, args Args, out_fn fn (string)) {
 		loop2: for pos > 0 {
 			len := mathutil.min(pos, buf_size)
 			pos = mathutil.max(pos - buf_size, 0)
-			buf := f.read_bytes_at(int(len), u64(pos))
+			f.read_bytes_into(u64(pos), mut buf) or { exit_error(err.msg()) }
 
 			for i := len - 1; i >= 0; i -= 1 {
 				if buf[i] == `\n` {

--- a/src/tail/tail.v
+++ b/src/tail/tail.v
@@ -60,13 +60,13 @@ fn tail_(args Args, out_fn fn (string)) {
 
 fn file_header(file string, first bool, args Args, out_fn fn (string)) {
 	if !first {
-		out_fn('')
+		out_fn('\n\n')
 	}
 	if args.quiet {
 		return
 	}
 	if args.files.len > 1 || args.verbose {
-		out_fn('===> ${file} <===')
+		out_fn('===> ${file} <===\n')
 	}
 }
 

--- a/src/tail/tail.v
+++ b/src/tail/tail.v
@@ -1,11 +1,16 @@
 // tail - output the last part of files
-import common
-import flag
 import os
 import time
 import v.mathutil
 
 const app_name = 'tail'
+
+struct FileInfo {
+	name string
+pub mut:
+	size  u64
+	stdin bool
+}
 
 fn main() {
 	args := get_args(os.args)
@@ -19,6 +24,7 @@ fn tail(args Args, out_fn fn (string)) {
 	mut tail_forever := false
 	mut files := args.files.map(FileInfo{ name: it })
 
+	// Perhaps there is a better way to handle stdin?
 	if args.files.len == 0 || args.files[0] == '-' {
 		tmp := tmp_from_stdin()
 		files = [FileInfo{
@@ -43,7 +49,7 @@ fn tail(args Args, out_fn fn (string)) {
 				file_header(file, leading_line_feeds, args, out_fn)
 
 				match true {
-					tail_forever { append_new_bytes(file, out_fn) }
+					tail_forever { tail_new_bytes(file, out_fn) }
 					args.bytes > 0 { tail_bytes(file, args, stat.size, out_fn) }
 					args.lines > 0 { tail_file(file, args, stat.size, out_fn) }
 					else { exit_error('invalid state') }
@@ -155,6 +161,12 @@ fn tail_file(file FileInfo, args Args, stat_size u64, out_fn fn (string)) {
 	}
 }
 
+fn tail_new_bytes(file FileInfo, out_fn fn (string)) {
+	mut f := os.open(file.name) or { exit_error(err.msg()) }
+	defer { f.close() }
+	print_file_at(f, file.size, out_fn)
+}
+
 fn print_file_at(file os.File, pos i64, out_fn fn (string)) {
 	mut idx := pos
 	buf_size := 4096
@@ -188,111 +200,4 @@ fn temp_file_name() string {
 	dir := os.temp_dir()
 	name := '${dir}/t${time.ticks()}'
 	return name
-}
-
-struct FileInfo {
-	name string
-pub mut:
-	size  u64
-	stdin bool
-}
-
-fn append_new_bytes(file FileInfo, out_fn fn (string)) {
-	mut f := os.open(file.name) or { exit_error(err.msg()) }
-	defer { f.close() }
-	print_file_at(f, file.size, out_fn)
-}
-
-struct Args {
-	bytes          i64
-	follow         bool
-	lines          i64
-	pid            string
-	quiet          bool
-	retry          bool
-	sleep_interval f64
-	verbose        bool
-	from_start     bool
-	delimiter      u8 = `\n`
-	files          []string
-}
-
-fn get_args(args []string) Args {
-	mut fp := flag.new_flag_parser(args)
-
-	fp.application(app_name)
-	fp.version(common.coreutils_version())
-	fp.skip_executable()
-	fp.description('
-		Print the last 10 lines of each FILE to standard output.
-		With more than one FILE, precede each with a header giving the file name.
-
-		With no FILE, or when FILE is -, read standard input.'.trim_indent())
-
-	eol := common.eol()
-	wrap := eol + flag.space
-
-	bytes_arg := fp.string('bytes', `c`, '-1',
-		'output the last NUM bytes; or use -c +<int> to output      ${wrap}' +
-		'starting with byte <int> of each file')
-
-	follow_arg := fp.bool('follow', `f`, false, 'output appended data as the file grows')
-	f_arg := fp.bool('', `F`, false, 'same as --follow=name --retry')
-
-	lines_arg := fp.string('lines', `n`, '10',
-		'output the last NUM lines, instead of the last 10; or us${wrap}' +
-		'-n +NUM to skip NUM-1 lines at the start')
-
-	pid_arg := fp.string('pid', ` `, '', 'with -f, terminate after process ID, PID dies')
-	quiet_arg := fp.bool('quiet', `q`, false, 'never output headers giving file names')
-	silent_arg := fp.bool('silent', ` `, false, 'same as --quiet')
-	retry_arg := fp.bool('retry', ` `, false, 'keep trying to open a file if it is inaccessible')
-
-	sleep_interval_arg := fp.float('sleep-interval', `s`, 1.0,
-		'with -f, sleep for approximately N seconds (default 1.0)${wrap}' +
-		'between iterations; with inotify and --pid=P, check${wrap}' +
-		'process P at least once every N seconds')
-
-	verbose_arg := fp.bool('verbose', `v`, false, 'always output headers giving file names')
-	zero_terminated_arg := fp.bool('zero-terminated', `z`, false, 'line delimiter is NUL, not newline')
-
-	fp.footer('
-
-		NUM may have a multiplier suffix: b 512, kB 1000, K 1024, MB
-		1000*1000, M 1024*1024, GB 1000*1000*1000, G 1024*1024*1024, and
-		so on for T, P, E, Z, Y, R, Q. Binary prefixes can be used, too:
-		KiB=K, MiB=M, and so on.
-
-		This implementation of TAIL follows files by name only. File
-		descriptors are not supported'.trim_indent())
-
-	fp.footer(common.coreutils_footer())
-	file_args := fp.finalize() or { exit_error(err.msg()) }
-	from_start := bytes_arg.starts_with('+') || lines_arg.starts_with('+')
-	delimiter := if zero_terminated_arg { `\0` } else { `\n` }
-
-	return Args{
-		bytes: string_to_i64(bytes_arg) or { exit_error(err.msg()) }
-		follow: follow_arg
-		lines: string_to_i64(lines_arg) or { exit_error(err.msg()) }
-		pid: pid_arg
-		quiet: quiet_arg || silent_arg
-		retry: f_arg || retry_arg
-		verbose: verbose_arg
-		sleep_interval: sleep_interval_arg
-		from_start: from_start
-		delimiter: delimiter
-		files: file_args
-	}
-}
-
-@[noreturn]
-fn exit_success(msg string) {
-	println(msg)
-	exit(0)
-}
-
-@[noreturn]
-fn exit_error(msg string) {
-	common.exit_with_error_message(app_name, msg)
 }

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -22,7 +22,7 @@ fn test_lines_opt_equals_two() {
 		files: ['test.txt']
 	}
 	out_fn, result_fn := setup()
-	tail_(args, out_fn)
+	tail(args, out_fn)
 
 	assert result_fn() == '
 		02: This tool will not produce all possible combination.
@@ -35,7 +35,7 @@ fn test_two_files_have_headers_separating_output() {
 		files: ['test.txt', 'test.txt']
 	}
 	out_fn, result_fn := setup()
-	tail_(args, out_fn)
+	tail(args, out_fn)
 
 	assert result_fn() == '
 		===> test.txt <===
@@ -54,7 +54,7 @@ fn test_lines_opt_equals_two_verbose() {
 		files: ['test.txt']
 	}
 	out_fn, result_fn := setup()
-	tail_(args, out_fn)
+	tail(args, out_fn)
 
 	assert result_fn() == '
 		===> test.txt <===
@@ -69,7 +69,7 @@ fn test_two_files_no_headers_quiet_option() {
 		files: ['test.txt', 'test.txt']
 	}
 	out_fn, result_fn := setup()
-	tail_(args, out_fn)
+	tail(args, out_fn)
 
 	assert result_fn() == '
 		02: This tool will not produce all possible combination.
@@ -86,7 +86,7 @@ fn test_from_start_lines() {
 		files: ['test.txt']
 	}
 	out_fn, result_fn := setup()
-	tail_(args, out_fn)
+	tail(args, out_fn)
 
 	assert result_fn() == '
 		02: This tool will not produce all possible combination.
@@ -100,6 +100,6 @@ fn test_from_start_bytes() {
 		files: ['test.txt']
 	}
 	out_fn, result_fn := setup()
-	tail_(args, out_fn)
+	tail(args, out_fn)
 	assert result_fn() == '02: This tool will not produce all possible combination.\n01: Output Box - Combination results will display here.'
 }

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -1,0 +1,5 @@
+module main
+
+fn test_stub() {
+	assert true
+}

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -1,5 +1,40 @@
 module main
 
-fn test_stub() {
-	assert true
+import os
+
+const test_text_content = [
+	'14: Privacy of Data: This tool is built-with and functi.',
+	'13: This will prevent browser lock-up from trying to lo.',
+	'12: When generating large amounts of combinations check.',
+	'11: Be aware of the number of combinations generated. O.',
+	'10: Entering \\x into any field will produce a line brea.',
+	'09: Empty object, prefix, suffix, join and delimiter fi.',
+	'09: More input boxes can be added via the "Add box." bu.',
+	'07: Combination sets are delimited via the "Join sets w.',
+	'06: Add a prefix and/or suffix to each set via the pref.',
+	'05: Enter object delimiter into "Delimiter" field.',
+	'04: Each input object must be on a new line.',
+	'03: *Combinations are produced from left to right i.e. .',
+	'02: This tool will not produce all possible combination.',
+	'01: Output Box - Combination results will display here.',
+]
+
+fn test_lines_opt_equals_two() {
+	args := Args{
+		lines: 2
+		files: ['test.txt']
+	}
+	mut result := []string{}
+	mut result_ref := &result
+	out_fn := fn [mut result_ref] (s string) {
+		result_ref << s
+	}
+
+	os.chdir(os.dir(@FILE))!
+	tail_(args, out_fn)
+
+	assert result == [
+		'02: This tool will not produce all possible combination.',
+		'01: Output Box - Combination results will display here.',
+	]
 }

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -99,3 +99,31 @@ fn test_two_files_no_headers_quiet_option() {
 		'01: Output Box - Combination results will display here.',
 	]
 }
+
+fn test_from_start_lines() {
+	args := Args{
+		lines: 13
+		from_start: true
+		files: ['test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail_(args, out_fn)
+
+	assert result_fn() == [
+		'01: Output Box - Combination results will display here.',
+	]
+}
+
+fn test_from_start_bytes() {
+	args := Args{
+		bytes: 666
+		from_start: true
+		files: ['test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail_(args, out_fn)
+
+	assert result_fn() == [
+		'02: This tool will not produce all possible combination.\n01: Output Box - Combination results will display here.',
+	]
+}

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -19,7 +19,7 @@ const test_text_content = [
 	'01: Output Box - Combination results will display here.',
 ]
 
-fn setup() (fn (s string), fn () []string) {
+fn setup() (fn (s string), fn () string) {
 	os.chdir(os.dir(@FILE)) or { exit_error(err.msg()) }
 
 	mut result := []string{}
@@ -27,8 +27,8 @@ fn setup() (fn (s string), fn () []string) {
 	out_fn := fn [mut result_ref] (s string) {
 		result_ref << s
 	}
-	result_fn := fn [mut result_ref] () []string {
-		return *result_ref
+	result_fn := fn [mut result_ref] () string {
+		return result_ref.join('')
 	}
 	return out_fn, result_fn
 }
@@ -41,10 +41,9 @@ fn test_lines_opt_equals_two() {
 	out_fn, result_fn := setup()
 	tail_(args, out_fn)
 
-	assert result_fn() == [
-		'02: This tool will not produce all possible combination.',
-		'01: Output Box - Combination results will display here.',
-	]
+	assert result_fn() == '
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
 }
 
 fn test_two_files_have_headers_separating_output() {
@@ -55,15 +54,14 @@ fn test_two_files_have_headers_separating_output() {
 	out_fn, result_fn := setup()
 	tail_(args, out_fn)
 
-	assert result_fn() == [
-		'===> test.txt <===',
-		'02: This tool will not produce all possible combination.',
-		'01: Output Box - Combination results will display here.',
-		'',
-		'===> test.txt <===',
-		'02: This tool will not produce all possible combination.',
-		'01: Output Box - Combination results will display here.',
-	]
+	assert result_fn() == '
+		===> test.txt <===
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.
+
+		===> test.txt <===
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
 }
 
 fn test_lines_opt_equals_two_verbose() {
@@ -75,11 +73,10 @@ fn test_lines_opt_equals_two_verbose() {
 	out_fn, result_fn := setup()
 	tail_(args, out_fn)
 
-	assert result_fn() == [
-		'===> test.txt <===',
-		'02: This tool will not produce all possible combination.',
-		'01: Output Box - Combination results will display here.',
-	]
+	assert result_fn() == '
+		===> test.txt <===
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
 }
 
 fn test_two_files_no_headers_quiet_option() {
@@ -91,13 +88,12 @@ fn test_two_files_no_headers_quiet_option() {
 	out_fn, result_fn := setup()
 	tail_(args, out_fn)
 
-	assert result_fn() == [
-		'02: This tool will not produce all possible combination.',
-		'01: Output Box - Combination results will display here.',
-		'',
-		'02: This tool will not produce all possible combination.',
-		'01: Output Box - Combination results will display here.',
-	]
+	assert result_fn() == '
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.
+
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
 }
 
 fn test_from_start_lines() {
@@ -109,9 +105,9 @@ fn test_from_start_lines() {
 	out_fn, result_fn := setup()
 	tail_(args, out_fn)
 
-	assert result_fn() == [
-		'01: Output Box - Combination results will display here.',
-	]
+	assert result_fn() == '
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
 }
 
 fn test_from_start_bytes() {
@@ -122,8 +118,5 @@ fn test_from_start_bytes() {
 	}
 	out_fn, result_fn := setup()
 	tail_(args, out_fn)
-
-	assert result_fn() == [
-		'02: This tool will not produce all possible combination.\n01: Output Box - Combination results will display here.',
-	]
+	assert result_fn() == '02: This tool will not produce all possible combination.\n01: Output Box - Combination results will display here.'
 }

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -20,7 +20,7 @@ const test_text_content = [
 ]
 
 fn setup() (fn (s string), fn () []string) {
-	os.chdir(os.dir(@FILE))!
+	os.chdir(os.dir(@FILE)) or { exit_error(err.msg()) }
 
 	mut result := []string{}
 	mut result_ref := &result
@@ -42,6 +42,27 @@ fn test_lines_opt_equals_two() {
 	tail_(args, out_fn)
 
 	assert result_fn() == [
+		'02: This tool will not produce all possible combination.',
+		'01: Output Box - Combination results will display here.',
+	]
+}
+
+fn test_two_files_have_headers_separating_output() {
+	args := Args{
+		lines: 2
+		files: ['test.txt', 'test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail_(args, out_fn)
+
+	assert result_fn() == [
+		'===> test.txt <===',
+		'',
+		'02: This tool will not produce all possible combination.',
+		'01: Output Box - Combination results will display here.',
+		'',
+		'===> test.txt <===',
+		'',
 		'02: This tool will not produce all possible combination.',
 		'01: Output Box - Combination results will display here.',
 	]

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -19,21 +19,29 @@ const test_text_content = [
 	'01: Output Box - Combination results will display here.',
 ]
 
-fn test_lines_opt_equals_two() {
-	args := Args{
-		lines: 2
-		files: ['test.txt']
-	}
+fn setup() (fn (s string), fn () []string) {
+	os.chdir(os.dir(@FILE))!
+
 	mut result := []string{}
 	mut result_ref := &result
 	out_fn := fn [mut result_ref] (s string) {
 		result_ref << s
 	}
+	result_fn := fn [mut result_ref] () []string {
+		return *result_ref
+	}
+	return out_fn, result_fn
+}
 
-	os.chdir(os.dir(@FILE))!
+fn test_lines_opt_equals_two() {
+	args := Args{
+		lines: 2
+		files: ['test.txt']
+	}
+	out_fn, result_fn := setup()
 	tail_(args, out_fn)
 
-	assert result == [
+	assert result_fn() == [
 		'02: This tool will not produce all possible combination.',
 		'01: Output Box - Combination results will display here.',
 	]

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -57,11 +57,43 @@ fn test_two_files_have_headers_separating_output() {
 
 	assert result_fn() == [
 		'===> test.txt <===',
-		'',
 		'02: This tool will not produce all possible combination.',
 		'01: Output Box - Combination results will display here.',
 		'',
 		'===> test.txt <===',
+		'02: This tool will not produce all possible combination.',
+		'01: Output Box - Combination results will display here.',
+	]
+}
+
+fn test_lines_opt_equals_two_verbose() {
+	args := Args{
+		lines: 2
+		verbose: true
+		files: ['test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail_(args, out_fn)
+
+	assert result_fn() == [
+		'===> test.txt <===',
+		'02: This tool will not produce all possible combination.',
+		'01: Output Box - Combination results will display here.',
+	]
+}
+
+fn test_two_files_no_headers_quiet_option() {
+	args := Args{
+		lines: 2
+		quiet: true
+		files: ['test.txt', 'test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail_(args, out_fn)
+
+	assert result_fn() == [
+		'02: This tool will not produce all possible combination.',
+		'01: Output Box - Combination results will display here.',
 		'',
 		'02: This tool will not produce all possible combination.',
 		'01: Output Box - Combination results will display here.',

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -2,23 +2,6 @@ module main
 
 import os
 
-const test_text_content = [
-	'14: Privacy of Data: This tool is built-with and functi.',
-	'13: This will prevent browser lock-up from trying to lo.',
-	'12: When generating large amounts of combinations check.',
-	'11: Be aware of the number of combinations generated. O.',
-	'10: Entering \\x into any field will produce a line brea.',
-	'09: Empty object, prefix, suffix, join and delimiter fi.',
-	'09: More input boxes can be added via the "Add box." bu.',
-	'07: Combination sets are delimited via the "Join sets w.',
-	'06: Add a prefix and/or suffix to each set via the pref.',
-	'05: Enter object delimiter into "Delimiter" field.',
-	'04: Each input object must be on a new line.',
-	'03: *Combinations are produced from left to right i.e. .',
-	'02: This tool will not produce all possible combination.',
-	'01: Output Box - Combination results will display here.',
-]
-
 fn setup() (fn (s string), fn () string) {
 	os.chdir(os.dir(@FILE)) or { exit_error(err.msg()) }
 

--- a/src/tail/test.txt
+++ b/src/tail/test.txt
@@ -1,0 +1,14 @@
+14: Privacy of Data: This tool is built-with and functi.
+13: This will prevent browser lock-up from trying to lo.
+12: When generating large amounts of combinations check.
+11: Be aware of the number of combinations generated. O.
+10: Entering \\x into any field will produce a line brea.
+09: Empty object, prefix, suffix, join and delimiter fi.
+09: More input boxes can be added via the "Add box." bu.
+07: Combination sets are delimited via the "Join sets w.
+06: Add a prefix and/or suffix to each set via the pref.
+05: Enter object delimiter into "Delimiter" field.
+04: Each input object must be on a new line.
+03: *Combinations are produced from left to right i.e. .
+02: This tool will not produce all possible combination.
+01: Output Box - Combination results will display here.

--- a/src/tail/test.txt
+++ b/src/tail/test.txt
@@ -2,7 +2,7 @@
 13: This will prevent browser lock-up from trying to lo.
 12: When generating large amounts of combinations check.
 11: Be aware of the number of combinations generated. O.
-10: Entering \\x into any field will produce a line brea.
+10: Entering \x into any field will produce a line brea.
 09: Empty object, prefix, suffix, join and delimiter fi.
 09: More input boxes can be added via the "Add box." bu.
 07: Combination sets are delimited via the "Join sets w.

--- a/src/tail/test.txt
+++ b/src/tail/test.txt
@@ -4,7 +4,7 @@
 11: Be aware of the number of combinations generated. O.
 10: Entering \x into any field will produce a line brea.
 09: Empty object, prefix, suffix, join and delimiter fi.
-09: More input boxes can be added via the "Add box." bu.
+08: More input boxes can be added via the "Add box." bu.
 07: Combination sets are delimited via the "Join sets w.
 06: Add a prefix and/or suffix to each set via the pref.
 05: Enter object delimiter into "Delimiter" field.


### PR DESCRIPTION
Tail implementation

- uses 4K buffers for read/write operations. Handles large files easily.
- `-f` option tracks by name, not descriptor. GNU uses descriptors but it really complicates things for little gain (imo)
- uses `ps` to track PID's. May not work on Windows although most developers probably have it installed because tasklist is a GUI