### PR TITLE
tail implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ count below and mark it as done in this README.md. Thanks!
 GNU coreutils. They are not 100% compatiable. If you encounter different behaviors, 
 compare against the true GNU coreutils version on the Linux-based tests first.
 
-## Completed (58/109)
+## Completed (59/109)
 
 |  Done   | Cmd       | Descripton                                       |
 | :-----: | --------- | ------------------------------------------------ |
@@ -138,7 +138,7 @@ compare against the true GNU coreutils version on the Linux-based tests first.
 |         | sum       | Print checksum and block counts                  |
 | &check; | sync      | Synchronize cached writes to persistent storage  |
 | &check; | tac       | Concatenate and write files in reverse           |
-|         | tail      | Output the last part of files                    |
+| &check; | tail      | Output the last part of files                    |
 |         | tee       | Redirect output to multiple files or processes   |
 | &check; | test      | Check file types and compare values              |
 |         | timeout   | Run a command with a time limit                  |

--- a/src/tail/cmd_line.v
+++ b/src/tail/cmd_line.v
@@ -1,0 +1,96 @@
+import common
+import flag
+
+struct Args {
+	bytes          i64
+	follow         bool
+	lines          i64
+	pid            string
+	quiet          bool
+	retry          bool
+	sleep_interval f64
+	verbose        bool
+	from_start     bool
+	delimiter      u8 = `\n`
+	files          []string
+}
+
+fn get_args(args []string) Args {
+	mut fp := flag.new_flag_parser(args)
+
+	fp.application(app_name)
+	fp.version(common.coreutils_version())
+	fp.skip_executable()
+	fp.description('
+		Print the last 10 lines of each FILE to standard output.
+		With more than one FILE, precede each with a header giving the file name.
+
+		With no FILE, or when FILE is -, read standard input.'.trim_indent())
+
+	eol := common.eol()
+	wrap := eol + flag.space
+
+	bytes_arg := fp.string('bytes', `c`, '-1',
+		'output the last NUM bytes; or use -c +<int> to output      ${wrap}' +
+		'starting with byte <int> of each file')
+
+	follow_arg := fp.bool('follow', `f`, false, 'output appended data as the file grows')
+	f_arg := fp.bool('', `F`, false, 'same as --follow=name --retry')
+
+	lines_arg := fp.string('lines', `n`, '10',
+		'output the last NUM lines, instead of the last 10; or us${wrap}' +
+		'-n +NUM to skip NUM-1 lines at the start')
+
+	pid_arg := fp.string('pid', ` `, '', 'with -f, terminate after process ID, PID dies')
+	quiet_arg := fp.bool('quiet', `q`, false, 'never output headers giving file names')
+	silent_arg := fp.bool('silent', ` `, false, 'same as --quiet')
+	retry_arg := fp.bool('retry', ` `, false, 'keep trying to open a file if it is inaccessible')
+
+	sleep_interval_arg := fp.float('sleep-interval', `s`, 1.0,
+		'with -f, sleep for approximately N seconds (default 1.0)${wrap}' +
+		'between iterations; with inotify and --pid=P, check${wrap}' +
+		'process P at least once every N seconds')
+
+	verbose_arg := fp.bool('verbose', `v`, false, 'always output headers giving file names')
+	zero_terminated_arg := fp.bool('zero-terminated', `z`, false, 'line delimiter is NUL, not newline')
+
+	fp.footer('
+
+		NUM may have a multiplier suffix: b 512, kB 1000, K 1024, MB
+		1000*1000, M 1024*1024, GB 1000*1000*1000, G 1024*1024*1024, and
+		so on for T, P, E, Z, Y, R, Q. Binary prefixes can be used, too:
+		KiB=K, MiB=M, and so on.
+
+		This implementation of TAIL follows files by name only. File
+		descriptors are not supported'.trim_indent())
+
+	fp.footer(common.coreutils_footer())
+	file_args := fp.finalize() or { exit_error(err.msg()) }
+	from_start := bytes_arg.starts_with('+') || lines_arg.starts_with('+')
+	delimiter := if zero_terminated_arg { `\0` } else { `\n` }
+
+	return Args{
+		bytes: string_to_i64(bytes_arg) or { exit_error(err.msg()) }
+		follow: follow_arg || f_arg
+		lines: string_to_i64(lines_arg) or { exit_error(err.msg()) }
+		pid: pid_arg
+		quiet: quiet_arg || silent_arg
+		retry: f_arg || retry_arg
+		verbose: verbose_arg
+		sleep_interval: sleep_interval_arg
+		from_start: from_start
+		delimiter: delimiter
+		files: file_args
+	}
+}
+
+@[noreturn]
+fn exit_success(msg string) {
+	println(msg)
+	exit(0)
+}
+
+@[noreturn]
+fn exit_error(msg string) {
+	common.exit_with_error_message(app_name, msg)
+}

--- a/src/tail/string_to_i64.v
+++ b/src/tail/string_to_i64.v
@@ -1,0 +1,76 @@
+// convert strings like 10K to i164
+const block = i64(512)
+
+// **1
+const kilo = i64(1024)
+const kilobyte = i64(1000)
+
+// **2
+const mega = kilo * kilo
+const megabyte = kilobyte * kilobyte
+
+// **3
+const giga = mega * kilo
+const gigabyte = megabyte * kilobyte
+
+// **4
+const terra = giga * kilo
+const terrabyte = gigabyte * kilobyte
+
+// **5
+const peta = terra * kilo
+const petabyte = terra * kilobyte
+
+// **6
+const exa = peta * kilo
+const exabyte = peta * kilo
+
+// **7
+const zetta = exa * kilo
+const zettabyte = exabyte * kilobyte
+
+fn string_to_i64(s string) ?i64 {
+	if s.len == 0 {
+		return none
+	}
+
+	mut index := 0
+	for index < s.len {
+		match true {
+			s[index].is_digit() {}
+			s[index] == `+` && index == 0 {}
+			s[index] == `-` && index == 0 {}
+			else { break }
+		}
+		index += 1
+	}
+
+	number := s[0..index].i64()
+	suffix := if index < s.len { s[index..] } else { 'c' }
+
+	multiplier := match suffix.to_lower() {
+		'b' { block }
+		'k' { kilo }
+		'kb', 'kib' { kilobyte }
+		'm' { mega }
+		'mb', 'mib' { megabyte }
+		'g' { giga }
+		'gb', 'gib' { gigabyte }
+		't' { terra }
+		'tb', 'tib' { terrabyte }
+		'p' { peta }
+		'pb', 'pib' { petabyte }
+		'e' { exa }
+		'eb', 'eib' { exabyte }
+		// oddball formats found in __xstrtol source
+		'c' { 1 }
+		'w' { 2 }
+		else { return none }
+	}
+
+	result := number * multiplier
+	if result == 0 && number != 0 {
+		return none
+	}
+	return result
+}

--- a/src/tail/string_to_i64_test.v
+++ b/src/tail/string_to_i64_test.v
@@ -1,0 +1,46 @@
+module main
+
+fn test_string_to_i64_conversions() {
+	assert string_to_i64('1')! == 1
+	assert string_to_i64('+1')! == 1
+	assert string_to_i64('-1')! == -1
+
+	assert string_to_i64('2b')! == 2 * block
+
+	assert string_to_i64('11k')! == 11 * kilo
+	assert string_to_i64('12K')! == 12 * kilo
+	assert string_to_i64('13KB')! == 13 * kilobyte
+	assert string_to_i64('14KiB')! == 14 * kilobyte
+
+	assert string_to_i64('15M')! == 15 * mega
+	assert string_to_i64('16MB')! == 16 * megabyte
+	assert string_to_i64('17mib')! == 17 * megabyte
+
+	assert string_to_i64('18T')! == 18 * terra
+	assert string_to_i64('18TB')! == 18 * terrabyte
+	assert string_to_i64('18TiB')! == 18 * terrabyte
+
+	assert string_to_i64('10P')! == 10 * peta
+	assert string_to_i64('10PB')! == 10 * petabyte
+	assert string_to_i64('10PiB')! == 10 * petabyte
+
+	assert string_to_i64('5E')! == 5 * exa
+	assert string_to_i64('5EB')! == 5 * exabyte
+	assert string_to_i64('5EiB')! == 5 * exabyte
+
+	overflow_r := string_to_i64('5R') or { -1 }
+	assert overflow_r == -1
+
+	overflow_q := string_to_i64('5Q') or { -1 }
+	assert overflow_q == -1
+
+	// invalid checks
+	t0 := string_to_i64('') or { -1 }
+	assert t0 == -1
+
+	t1 := string_to_i64('1x') or { -1 }
+	assert t1 == -1
+
+	t2 := string_to_i64('++1') or { -1 }
+	assert t2 == -1
+}

--- a/src/tail/tail.v
+++ b/src/tail/tail.v
@@ -1,0 +1,203 @@
+// tail - output the last part of files
+import os
+import time
+import v.mathutil
+
+const app_name = 'tail'
+
+struct FileInfo {
+	name string
+pub mut:
+	size  u64
+	stdin bool
+}
+
+fn main() {
+	args := get_args(os.args)
+	tail(args, fn (s string) {
+		print(s)
+		flush_stdout()
+	})
+}
+
+fn tail(args Args, out_fn fn (string)) {
+	mut tail_forever := false
+	mut files := args.files.map(FileInfo{ name: it })
+
+	// Perhaps there is a better way to handle stdin?
+	if args.files.len == 0 || args.files[0] == '-' {
+		tmp := tmp_from_stdin()
+		files = [FileInfo{
+			name: tmp
+			stdin: true
+		}]
+	}
+
+	for {
+		for i, mut file in files {
+			stat := os.stat(file.name) or {
+				if args.retry {
+					continue
+				}
+				exit_error(err.msg())
+			}
+
+			if stat.size < file.size {
+				out_fn('\n===> ${file.name} truncated <===\n')
+			} else if stat.size != file.size {
+				leading_line_feeds := i > 0 || (tail_forever && args.files.len > 1)
+				file_header(file, leading_line_feeds, args, out_fn)
+
+				match true {
+					tail_forever { tail_new_bytes(file, out_fn) }
+					args.bytes > 0 { tail_bytes(file, args, stat.size, out_fn) }
+					args.lines > 0 { tail_file(file, args, stat.size, out_fn) }
+					else { exit_error('invalid state') }
+				}
+			}
+
+			file.size = stat.size
+		}
+
+		if args.follow {
+			tail_forever = true
+			time.sleep(i64(args.sleep_interval * time.second))
+			if args.pid.len > 0 {
+				result := os.execute('ps ${args.pid}')
+				if result.exit_code != 0 {
+					break
+				}
+			}
+			continue
+		}
+		break
+	}
+}
+
+fn file_header(file FileInfo, leading_line_feeds bool, args Args, out_fn fn (string)) {
+	if leading_line_feeds {
+		out_fn('\n\n')
+	}
+	if args.quiet {
+		return
+	}
+	name := if file.stdin { 'standard input' } else { file.name }
+	if args.files.len > 1 || args.verbose {
+		out_fn('===> ${name} <===\n')
+	}
+}
+
+fn tail_bytes(file FileInfo, args Args, stat_size u64, out_fn fn (string)) {
+	pos := if args.from_start {
+		args.bytes
+	} else {
+		mathutil.max(u64(0), stat_size - u64(args.bytes))
+	}
+	mut f := os.open(file.name) or {
+		if args.retry {
+			return
+		}
+		exit_error(err.msg())
+	}
+	defer { f.close() }
+	print_file_at(f, pos, out_fn)
+}
+
+fn tail_file(file FileInfo, args Args, stat_size u64, out_fn fn (string)) {
+	mut f := os.open(file.name) or {
+		if args.retry {
+			return
+		}
+		exit_error(err.msg())
+	}
+	defer { f.close() }
+
+	buf_size := i64(4096)
+	mut buf := []u8{len: int(buf_size)}
+	mut count := 0
+	end := i64(stat_size)
+
+	if args.from_start {
+		mut pos := i64(0)
+
+		loop1: for pos <= end {
+			len := mathutil.min(end - pos, buf_size)
+			f.read_bytes_into(u64(pos), mut buf) or { exit_error(err.msg()) }
+
+			for i := 0; i < len; i += 1 {
+				if buf[i] == args.delimiter {
+					count += 1
+					if count >= args.lines - 1 {
+						pos = pos + i + 1
+						break loop1
+					}
+				}
+			}
+
+			pos += buf_size + 1
+		}
+
+		print_file_at(f, pos, out_fn)
+	} else {
+		mut pos := end
+
+		loop2: for pos > 0 {
+			len := mathutil.min(pos, buf_size)
+			pos = mathutil.max(pos - buf_size, 0)
+			f.read_bytes_into(u64(pos), mut buf) or { exit_error(err.msg()) }
+
+			for i := len - 1; i >= 0; i -= 1 {
+				if buf[i] == args.delimiter {
+					count += 1
+					if count >= args.lines {
+						pos = pos + i + 1
+						break loop2
+					}
+				}
+			}
+		}
+
+		print_file_at(f, pos, out_fn)
+	}
+}
+
+fn tail_new_bytes(file FileInfo, out_fn fn (string)) {
+	mut f := os.open(file.name) or { exit_error(err.msg()) }
+	defer { f.close() }
+	print_file_at(f, file.size, out_fn)
+}
+
+fn print_file_at(file os.File, pos i64, out_fn fn (string)) {
+	mut idx := pos
+	buf_size := 4096
+	mut buf := []u8{len: buf_size}
+	mut bytes_read := buf_size
+
+	for bytes_read == buf_size {
+		bytes_read = file.read_bytes_into(u64(idx), mut buf) or { exit_error(err.msg()) }
+		out_fn(buf[0..bytes_read].bytestr())
+		idx += bytes_read
+	}
+}
+
+fn tmp_from_stdin() string {
+	tmp := temp_file_name()
+	os.create(tmp) or { exit_error(err.msg()) }
+	mut f := os.open_append(tmp) or { exit_error(err.msg()) }
+	defer { f.close() }
+
+	for {
+		s := os.get_raw_line()
+		if s.len == 0 {
+			break
+		}
+		f.write_string(s) or { exit_error(err.msg()) }
+	}
+	return tmp
+}
+
+fn temp_file_name() string {
+	dir := os.temp_dir()
+	name := '${dir}/t${time.ticks()}'
+	return name
+}

--- a/src/tail/tail_test.v
+++ b/src/tail/tail_test.v
@@ -1,0 +1,105 @@
+module main
+
+import os
+
+fn setup() (fn (s string), fn () string) {
+	os.chdir(os.dir(@FILE)) or { exit_error(err.msg()) }
+
+	mut result := []string{}
+	mut result_ref := &result
+	out_fn := fn [mut result_ref] (s string) {
+		result_ref << s
+	}
+	result_fn := fn [mut result_ref] () string {
+		return result_ref.join('')
+	}
+	return out_fn, result_fn
+}
+
+fn test_lines_opt_equals_two() {
+	args := Args{
+		lines: 2
+		files: ['test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail(args, out_fn)
+
+	assert result_fn() == '
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
+}
+
+fn test_two_files_have_headers_separating_output() {
+	args := Args{
+		lines: 2
+		files: ['test.txt', 'test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail(args, out_fn)
+
+	assert result_fn() == '
+		===> test.txt <===
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.
+
+		===> test.txt <===
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
+}
+
+fn test_lines_opt_equals_two_verbose() {
+	args := Args{
+		lines: 2
+		verbose: true
+		files: ['test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail(args, out_fn)
+
+	assert result_fn() == '
+		===> test.txt <===
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
+}
+
+fn test_two_files_no_headers_quiet_option() {
+	args := Args{
+		lines: 2
+		quiet: true
+		files: ['test.txt', 'test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail(args, out_fn)
+
+	assert result_fn() == '
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.
+
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
+}
+
+fn test_from_start_lines() {
+	args := Args{
+		lines: 13
+		from_start: true
+		files: ['test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail(args, out_fn)
+
+	assert result_fn() == '
+		02: This tool will not produce all possible combination.
+		01: Output Box - Combination results will display here.'.trim_indent()
+}
+
+fn test_from_start_bytes() {
+	args := Args{
+		bytes: 666
+		from_start: true
+		files: ['test.txt']
+	}
+	out_fn, result_fn := setup()
+	tail(args, out_fn)
+	assert result_fn() == '02: This tool will not produce all possible combination.\n01: Output Box - Combination results will display here.'
+}

--- a/src/tail/test.txt
+++ b/src/tail/test.txt
@@ -1,0 +1,14 @@
+14: Privacy of Data: This tool is built-with and functi.
+13: This will prevent browser lock-up from trying to lo.
+12: When generating large amounts of combinations check.
+11: Be aware of the number of combinations generated. O.
+10: Entering \x into any field will produce a line brea.
+09: Empty object, prefix, suffix, join and delimiter fi.
+08: More input boxes can be added via the "Add box." bu.
+07: Combination sets are delimited via the "Join sets w.
+06: Add a prefix and/or suffix to each set via the pref.
+05: Enter object delimiter into "Delimiter" field.
+04: Each input object must be on a new line.
+03: *Combinations are produced from left to right i.e. .
+02: This tool will not produce all possible combination.
+01: Output Box - Combination results will display here.


### PR DESCRIPTION
Tail implementation

- uses 4K buffers for read/write operations. Handles large files easily.
- `-f` option tracks by name, not descriptor. GNU uses descriptors but it really complicates things for little gain (imo)
- uses `ps` to track PID's. May not work on Windows although most developers probably have it installed because tasklist is a GUI