### PR TITLE
basenc implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ count below and mark it as done in this README.md. Thanks!
 GNU coreutils. They are not 100% compatiable. If you encounter different behaviors,
 compare against the true GNU coreutils version on the Linux-based tests first.
 
-## Completed (63/109)
+## Completed (65/109)
 
 |  Done   | Cmd       | Descripton                                       |
 | :-----: | --------- | ------------------------------------------------ |
@@ -56,7 +56,7 @@ compare against the true GNU coreutils version on the Linux-based tests first.
 | &check; | base32    | Transform data into printable data               |
 | &check; | base64    | Transform data into printable data               |
 | &check; | basename  | Strip directory and suffix from a file name      |
-|         | basenc    | Transform data into printable data               |
+| &check; | basenc    | Transform data into printable data               |
 | &check; | cat       | Concatenate and write files                      |
 |         | chcon     | Change SELinux context of file                   |
 |         | chgrp     | Change group ownership                           |

--- a/src/basenc/basenc.v
+++ b/src/basenc/basenc.v
@@ -1,0 +1,267 @@
+import os
+import v.mathutil
+import encoding.base64
+import encoding.base32
+
+fn main() {
+	options := get_options()
+	for file in options.files {
+		if options.decode {
+			lines := os.read_lines(file) or { exit_error(err.msg()) }
+			content := lines.join('')
+			print(decode(content, options))
+		} else {
+			content := os.read_bytes(file) or { exit_error(err.msg()) }
+			print_encoded(encode(content, options), options)
+		}
+	}
+}
+
+fn encode(content []u8, options Options) string {
+	return match true {
+		options.base64 { base64.encode(content) }
+		options.base64url { base64.url_encode(content) }
+		options.base32 { base32.encode_to_string(content) }
+		options.base32hex { base32hex_encode_to_string(content) }
+		options.base16 { base16_encode(content) }
+		options.base2msbf { base2msbf_encode(content) }
+		options.base2lsbf { base2lsbf_encode(content) }
+		options.z85 { z85_encode(content) }
+		else { exit_error('must specify encoding option') }
+	}
+}
+
+fn decode(content string, options Options) string {
+	return match true {
+		options.base64 { base64.decode_str(content) }
+		options.base64url { base64.url_decode_str(content) }
+		options.base32 { base32.decode_string_to_string(content) or { exit_error(err.msg()) } }
+		options.base32hex { base32hex_decode_to_string(content) }
+		options.base16 { base16_decode(content) }
+		options.base2msbf { base2msbf_decode(content) }
+		options.base2lsbf { base2lsbf_decode(content) }
+		options.z85 { z85_decode(content) }
+		else { exit_error('must specify encoding option') }
+	}
+}
+
+fn print_encoded(encoded string, options Options) {
+	if options.wrap == 0 {
+		println(encoded)
+		return
+	}
+	for start := 0; start < encoded.len; start += options.wrap {
+		end := mathutil.min(start + options.wrap, encoded.len)
+		// safe to use string slicing because all chars
+		// are in printable ascii
+		println(encoded[start..end])
+	}
+}
+
+fn base32hex_encode_to_string(content []u8) string {
+	norm_to_hex := [u8(`Q`), `R`, `S`, `T`, `U`, `V`, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e,
+		0x3f, 0x40, `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `A`, `B`, `C`, `D`, `E`,
+		`F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`, `P`]
+
+	b32 := base32.encode(content)
+	mut buf := []u8{len: b32.len, init: 0}
+	for i, c in b32 {
+		buf[i] = norm_to_hex[c - 0x32]
+	}
+	return buf.bytestr()
+}
+
+fn base32hex_decode_to_string(content string) string {
+	hex_to_norm := [u8(`A`), `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, 0x3a, 0x3b, 0x3c, 0x3d,
+		0x3e, 0x3f, 0x40, `K`, `L`, `M`, `N`, `O`, `P`, `Q`, `R`, `S`, `T`, `U`, `V`, `W`, `X`,
+		`Y`, `Z`, `2`, `3`, `4`, `5`, `6`, `7`]
+	mut buf := []u8{len: content.len, init: 0}
+	for i, c in content {
+		buf[i] = hex_to_norm[c - 0x30]
+	}
+	return base32.decode_to_string(buf) or { exit_error(err.msg()) }
+}
+
+const base16_codes = [`0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `A`, `B`, `C`, `D`, `E`,
+	`F`]
+
+fn base16_encode(content []u8) string {
+	mut buffer := []u8{len: content.len * 2, init: 0}
+	mut idx := 0
+	for c in content {
+		buffer[idx] = base16_codes[c >> 4]
+		buffer[idx + 1] = base16_codes[c & 0x0F]
+		idx += 2
+	}
+	return buffer.bytestr()
+}
+
+fn base16_decode(content string) string {
+	mut buffer := []u8{len: content.len / 2, init: 0}
+	mut idx := 0
+	for i := 0; i < content.len; i += 2 {
+		u := base16_codes.index(content[i])
+		l := base16_codes.index(content[i + 1])
+		buffer[idx] = u8(u) << 4 | u8(l)
+		idx += 1
+	}
+	return buffer.bytestr()
+}
+
+fn base2msbf_encode(content []u8) string {
+	mut buffer := []u8{len: content.len * 8, init: 0}
+	mut idx := 0
+	for c in content {
+		buffer[idx + 0] = emit(c & 0b10000000)
+		buffer[idx + 1] = emit(c & 0b01000000)
+		buffer[idx + 2] = emit(c & 0b00100000)
+		buffer[idx + 3] = emit(c & 0b00010000)
+		buffer[idx + 4] = emit(c & 0b00001000)
+		buffer[idx + 5] = emit(c & 0b00000100)
+		buffer[idx + 6] = emit(c & 0b00000010)
+		buffer[idx + 7] = emit(c & 0b00000001)
+		idx += 8
+	}
+	return buffer.bytestr()
+}
+
+fn base2msbf_decode(content string) string {
+	if content.len % 8 != 0 {
+		exit_error('content length must be a multiple of 8')
+	}
+	mut idx := 0
+	mut buffer := []u8{len: content.len / 8, init: 0}
+	for i := 0; i < content.len; i += 8 {
+		b7 := if content[i + 0] == `1` { 0b10000000 } else { 0b0 }
+		b6 := if content[i + 1] == `1` { 0b01000000 } else { 0b0 }
+		b5 := if content[i + 2] == `1` { 0b00100000 } else { 0b0 }
+		b4 := if content[i + 3] == `1` { 0b00010000 } else { 0b0 }
+		b3 := if content[i + 4] == `1` { 0b00001000 } else { 0b0 }
+		b2 := if content[i + 5] == `1` { 0b00000100 } else { 0b0 }
+		b1 := if content[i + 6] == `1` { 0b00000010 } else { 0b0 }
+		b0 := if content[i + 7] == `1` { 0b00000001 } else { 0b0 }
+
+		buffer[idx] = u8(b7 | b6 | b5 | b4 | b3 | b2 | b1 | b0)
+		idx += 1
+	}
+	return buffer.bytestr()
+}
+
+fn base2lsbf_encode(content []u8) string {
+	mut buffer := []u8{len: content.len * 8, init: 0}
+	mut idx := 0
+	for c in content {
+		buffer[idx + 0] = emit(c & 0b00000001)
+		buffer[idx + 1] = emit(c & 0b00000010)
+		buffer[idx + 2] = emit(c & 0b00000100)
+		buffer[idx + 3] = emit(c & 0b00001000)
+		buffer[idx + 4] = emit(c & 0b00010000)
+		buffer[idx + 5] = emit(c & 0b00100000)
+		buffer[idx + 6] = emit(c & 0b01000000)
+		buffer[idx + 7] = emit(c & 0b10000000)
+		idx += 8
+	}
+	return buffer.bytestr()
+}
+
+fn base2lsbf_decode(content string) string {
+	if content.len % 8 != 0 {
+		exit_error('content length must be a multiple of 8')
+	}
+	mut idx := 0
+	mut buffer := []u8{len: content.len / 8, init: 0}
+	for i := 0; i < content.len; i += 8 {
+		b7 := if content[i + 0] == `1` { 0b00000001 } else { 0b0 }
+		b6 := if content[i + 1] == `1` { 0b00000010 } else { 0b0 }
+		b5 := if content[i + 2] == `1` { 0b00000100 } else { 0b0 }
+		b4 := if content[i + 3] == `1` { 0b00001000 } else { 0b0 }
+		b3 := if content[i + 4] == `1` { 0b00010000 } else { 0b0 }
+		b2 := if content[i + 5] == `1` { 0b00100000 } else { 0b0 }
+		b1 := if content[i + 6] == `1` { 0b01000000 } else { 0b0 }
+		b0 := if content[i + 7] == `1` { 0b10000000 } else { 0b0 }
+
+		buffer[idx] = u8(b7 | b6 | b5 | b4 | b3 | b2 | b1 | b0)
+		idx += 1
+	}
+	return buffer.bytestr()
+}
+
+fn emit(val u8) u8 {
+	return if val > 0 { `1` } else { `0` }
+}
+
+const z85_codes = [`0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `a`, `b`, `c`, `d`, `e`, `f`,
+	`g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `p`, `q`, `r`, `s`, `t`, `u`, `v`, `w`, `z`, `y`,
+	`z`, `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`, `P`, `Q`, `R`,
+	`S`, `T`, `U`, `V`, `W`, `X`, `Y`, `Z`, `.`, `-`, `:`, `+`, `=`, `^`, `!`, `/`, `*`, `?`, `&`,
+	`<`, `>`, `(`, `)`, `[`, `]`, `{`, `}`, `@`, `%`, `$`, `#`]
+
+fn z85_encode(content []u8) string {
+	if content.len % 4 != 0 {
+		exit_error('invalid input (length must be multiple of 4 characters)')
+	}
+
+	mut start := 0
+	mut buf := []u8{len: (content.len / 4) * 5, init: 0}
+	for i := 0; i < content.len; i += 4 {
+		mut frame := u32(0)
+		frame |= u32(content[i + 0]) << 24
+		frame |= u32(content[i + 1]) << 16
+		frame |= u32(content[i + 2]) << 8
+		frame |= u32(content[i + 3])
+
+		// Convert into 5 characters, dividing by 85 and taking the remainder
+		mut divisor := u32(52200625) // 85 * 85 * 85 * 85;
+		for j := 0; j < 5; j++ {
+			divisible := (frame / divisor) % 85
+			buf[start + j] = z85_codes[divisible]
+			frame -= divisible * divisor
+			divisor /= 85
+		}
+		start += 5
+	}
+
+	return buf.bytestr()
+}
+
+const base256 = [u8(0x00), 0x44, 0x00, 0x54, 0x53, 0x52, 0x48, 0x00, 0x4B, 0x4C, 0x46, 0x41, 0x00,
+	0x3F, 0x3E, 0x45, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x40, 0x00, 0x49,
+	0x42, 0x4A, 0x47, 0x51, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F,
+	0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x4D, 0x00,
+	0x4E, 0x43, 0x00, 0x00, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+	0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x4F, 0x00,
+	0x50, 0x00, 0x00]
+
+fn z85_decode(content string) string {
+	if content.len % 5 != 0 {
+		exit_error('invalid input (length must be multiple of 5 characters)')
+	}
+
+	mut buf := []u8{len: (content.len / 5) * 4, init: 0}
+	mut idx := 0
+	mut val := u32(0)
+
+	for i := 0; i < content.len; i += 5 {
+		val = base256[(content[i + 0] - 32) & 127]
+		val = val * 85 + base256[(content[i + 1] - 32) & 127]
+		val = val * 85 + base256[(content[i + 2] - 32) & 127]
+		val = val * 85 + base256[(content[i + 3] - 32) & 127]
+		val = val * 85 + base256[(content[i + 4] - 32) & 127]
+
+		buf[idx] = u8(val >> 24)
+		val = val << 8 >> 8
+		idx += 1
+
+		buf[idx] = u8(val >> 16)
+		val = val << 16 >> 16
+		idx += 1
+
+		buf[idx] = u8(val >> 8)
+		val = val << 24 >> 24
+		idx += 1
+
+		buf[idx] = u8(val)
+		idx += 1
+	}
+	return buf.bytestr()
+}

--- a/src/basenc/basenc_test.v
+++ b/src/basenc/basenc_test.v
@@ -1,0 +1,188 @@
+module main
+
+fn test_encode_base64() {
+	options := Options{
+		base64: true
+	}
+	assert encode([]u8{}, options) == ''
+	assert encode('f'.bytes(), options) == 'Zg=='
+	assert encode('fo'.bytes(), options) == 'Zm8='
+	assert encode('foo'.bytes(), options) == 'Zm9v'
+	assert encode('foob'.bytes(), options) == 'Zm9vYg=='
+	assert encode('fooba'.bytes(), options) == 'Zm9vYmE='
+	assert encode('foobar'.bytes(), options) == 'Zm9vYmFy'
+}
+
+fn test_decode_base64() {
+	options := Options{
+		base64: true
+		decode: true
+	}
+	assert decode('Zm9vYmFy', options) == 'foobar'
+	assert decode('Zm9vYmE=', options) == 'fooba'
+	assert decode('ViBpbiBiYXNlIDY0', options) == 'V in base 64'
+}
+
+// ------------
+
+fn test_encode_base64url() {
+	options := Options{
+		base64url: true
+	}
+	assert encode([]u8{}, options) == ''
+	assert encode('f'.bytes(), options) == 'Zg'
+	assert encode('fo'.bytes(), options) == 'Zm8'
+	assert encode('foo'.bytes(), options) == 'Zm9v'
+	assert encode('foob'.bytes(), options) == 'Zm9vYg'
+	assert encode('fooba'.bytes(), options) == 'Zm9vYmE'
+	assert encode('foobar'.bytes(), options) == 'Zm9vYmFy'
+}
+
+fn test_decode_base64url() {
+	options := Options{
+		base64url: true
+		decode: true
+	}
+	assert decode('Zg', options) == 'f'
+	assert decode('Zm8', options) == 'fo'
+	assert decode('Zm9v', options) == 'foo'
+	assert decode('Zm9vYg', options) == 'foob'
+	assert decode('Zm9vYmE', options) == 'fooba'
+	assert decode('Zm9vYmFy', options) == 'foobar'
+}
+
+// ------------
+
+fn test_encode_base32() {
+	options := Options{
+		base32: true
+	}
+	assert encode([]u8{}, options) == ''
+	assert encode('f'.bytes(), options) == 'MY======'
+	assert encode('fo'.bytes(), options) == 'MZXQ===='
+	assert encode('foo'.bytes(), options) == 'MZXW6==='
+	assert encode('foob'.bytes(), options) == 'MZXW6YQ='
+	assert encode('fooba'.bytes(), options) == 'MZXW6YTB'
+	assert encode('foobar'.bytes(), options) == 'MZXW6YTBOI======'
+}
+
+fn test_decode_base32() {
+	options := Options{
+		base32: true
+		decode: true
+	}
+	assert decode('MY======', options) == 'f'
+	assert decode('MZXQ====', options) == 'fo'
+	assert decode('MZXW6===', options) == 'foo'
+	assert decode('MZXW6YQ=', options) == 'foob'
+	assert decode('MZXW6YTB', options) == 'fooba'
+	assert decode('MZXW6YTBOI======', options) == 'foobar'
+}
+
+// ------------
+
+fn test_encode_base32hex() {
+	options := Options{
+		base32hex: true
+	}
+	assert encode([]u8{}, options) == ''
+	assert encode('f'.bytes(), options) == 'CO======'
+	assert encode('fo'.bytes(), options) == 'CPNG===='
+	assert encode('foo'.bytes(), options) == 'CPNMU==='
+	assert encode('foob'.bytes(), options) == 'CPNMUOG='
+	assert encode('fooba'.bytes(), options) == 'CPNMUOJ1'
+	assert encode('foobar'.bytes(), options) == 'CPNMUOJ1E8======'
+}
+
+fn test_decode_base32hex() {
+	options := Options{
+		base32hex: true
+		decode: true
+	}
+	assert decode('CO======', options) == 'f'
+	assert decode('CPNG====', options) == 'fo'
+	assert decode('CPNMU===', options) == 'foo'
+	assert decode('CPNMUOG=', options) == 'foob'
+	assert decode('CPNMUOJ1', options) == 'fooba'
+	assert decode('CPNMUOJ1E8======', options) == 'foobar'
+}
+
+// ------------
+
+fn test_encode_base16() {
+	options := Options{
+		base16: true
+	}
+	assert encode([]u8{}, options) == ''
+	assert encode('f'.bytes(), options) == '66'
+	assert encode('fo'.bytes(), options) == '666F'
+	assert encode('foo'.bytes(), options) == '666F6F'
+	assert encode('foob'.bytes(), options) == '666F6F62'
+	assert encode('fooba'.bytes(), options) == '666F6F6261'
+	assert encode('foobar'.bytes(), options) == '666F6F626172'
+}
+
+fn test_decode_base16() {
+	options := Options{
+		base16: true
+	}
+	assert decode('66', options) == 'f'
+	assert decode('666F', options) == 'fo'
+	assert decode('666F6F', options) == 'foo'
+	assert decode('666F6F62', options) == 'foob'
+	assert decode('666F6F6261', options) == 'fooba'
+	assert decode('666F6F626172', options) == 'foobar'
+}
+
+// ------------
+
+fn test_encode_base2lbsf() {
+	options := Options{
+		base2lsbf: true
+	}
+	assert encode('foobar'.bytes(), options) == '011001101111011011110110010001101000011001001110'
+}
+
+fn test_dncode_base2lbsf() {
+	options := Options{
+		base2lsbf: true
+		decode: true
+	}
+	assert decode('011001101111011011110110010001101000011001001110', options) == 'foobar'
+}
+
+// ------------
+
+fn test_encode_base2mbsf() {
+	options := Options{
+		base2msbf: true
+	}
+	assert encode('foobar'.bytes(), options) == '011001100110111101101111011000100110000101110010'
+}
+
+fn test_decode_base2mbsf() {
+	options := Options{
+		base2msbf: true
+		decode: true
+	}
+	assert decode('011001100110111101101111011000100110000101110010', options) == 'foobar'
+}
+
+// ------------
+
+fn test_encode_z85() {
+	options := Options{
+		z85: true
+	}
+	// from the specification (https://rfc.zeromq.org/spec/32/)
+	assert encode([u8(0x86), 0x4F, 0xD2, 0x6F, 0xB5, 0x59, 0xF7, 0x5B], options) == 'HelloWorld'
+}
+
+fn test_decode_z85() {
+	options := Options{
+		z85: true
+		decode: true
+	}
+	assert decode('HelloWorld', options).bytes() == [u8(0x86), 0x4F, 0xD2, 0x6F, 0xB5, 0x59, 0xF7,
+		0x5B]
+}

--- a/src/basenc/options.v
+++ b/src/basenc/options.v
@@ -1,0 +1,97 @@
+import common
+import flag
+import os
+import time
+
+const app_name = 'basenc'
+
+struct Options {
+	base64    bool
+	base64url bool
+	base32    bool
+	base32hex bool
+	base16    bool
+	base2msbf bool
+	base2lsbf bool
+	decode    bool
+	wrap      int
+	z85       bool
+	files     []string
+}
+
+fn get_options() Options {
+	mut fp := common.flag_parser(os.args)
+	fp.application(app_name)
+	fp.arguments_description('[FILE]')
+	fp.description('\nEncode or decode FILE, or standard input, to standard output.\n' +
+		'With no FILE, or when FILE is -, read standard input.'.trim_indent())
+
+	base64 := fp.bool('base64', ` `, false, "same as 'base64' program (RFC4648 section 4)")
+	base64url := fp.bool('base64url', ` `, false, 'file- and url-safe base64 (RFC4648 section 5)')
+	base32 := fp.bool('base32', ` `, false, 'file- and url-safe base64 (RFC4648 section 5)')
+	base32hex := fp.bool('base32hex', ` `, false, 'extended hex alphabet base32 (RFC4648 section 7)')
+	base16 := fp.bool('base16', ` `, false, 'hex encoding (RFC4648 section 8)')
+	base2msbf := fp.bool('base2msbf', ` `, false, 'bit string with most significant bit (msb) first')
+	base2lsbf := fp.bool('base2lsbf', ` `, false, 'bit string with least significant bit (lsb) first')
+	decode := fp.bool('decode', `d`, false, 'decode data')
+	wrap := fp.int('wrap', `w`, 76,
+		'wrap encoded lines after <int> COLS character (default 76)\n${flag.space}' +
+		'Use 0 to disable line wrapping')
+	z85 := fp.bool('z85', ` `, false,
+		'ascii85-like encoding (ZeroMQ spec:32/Z85); when encoding,\n${flag.space}' +
+		'input length must be a multiple of 4; when decoding, input\n${flag.space}' +
+		'length must be a multiple of 5\n')
+
+	files := fp.finalize() or { exit_error(err.msg()) }
+
+	return Options{
+		base64: base64
+		base64url: base64url
+		base32: base32
+		base32hex: base32hex
+		base16: base16
+		base2msbf: base2msbf
+		base2lsbf: base2lsbf
+		decode: decode
+		wrap: wrap
+		z85: z85
+		files: scan_files_arg(files)
+	}
+}
+
+fn scan_files_arg(files_arg []string) []string {
+	mut files := []string{}
+	for file in files_arg {
+		if file == '-' {
+			files << stdin_to_tmp()
+			continue
+		}
+		files << file
+	}
+	if files.len == 0 {
+		files << stdin_to_tmp()
+	}
+	return files
+}
+
+const tmp_pattern = '/${app_name}-tmp-'
+
+fn stdin_to_tmp() string {
+	tmp := '${os.temp_dir()}/${tmp_pattern}${time.ticks()}'
+	os.create(tmp) or { exit_error(err.msg()) }
+	mut f := os.open_append(tmp) or { exit_error(err.msg()) }
+	defer { f.close() }
+	for {
+		s := os.get_raw_line()
+		if s.len == 0 {
+			break
+		}
+		f.write_string(s) or { exit_error(err.msg()) }
+	}
+	return tmp
+}
+
+@[noreturn]
+fn exit_error(msg string) {
+	common.exit_with_error_message(app_name, msg)
+}


### PR DESCRIPTION
The --z85 encoding is one I had not heard of before. Fixes several issues with base64 interop implementations according to the RFC.

The base16, base32hex, binary (lsbf & msbf) and z85 implementations are not present in the V's standard library.  Should they? The ones in this program are straightforward and could be added. I'm willing to do the work.

Talk it over with the team if you're interested and let me know.