### PR TITLE
fix some problems that prevent tests from running

### DIFF
--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -8,30 +8,15 @@ import regex
 // so that they can be used as more specific errors,
 // in place of `return error(message)`
 struct DidNotFailError implements IError {
-	Error
-	msg string
-}
-
-pub fn (err DidNotFailError) msg() string {
-	return err.msg()
+	MessageError
 }
 
 struct DoesNotWorkError implements IError {
-	Error
-	msg string
-}
-
-pub fn (err DoesNotWorkError) msg() string {
-	return err.msg()
+	MessageError
 }
 
 struct ExitCodesDifferError implements IError {
-	Error
-	msg string
-}
-
-pub fn (err ExitCodesDifferError) msg() string {
-	return err.msg()
+	MessageError
 }
 
 // CommandPair remembers what original command we are trying to test against
@@ -64,7 +49,7 @@ pub fn (p CommandPair) same_results(options string) bool {
 // expected_failure - given some options, execute both the original
 // and the deputy commands with them, and ensure that they both fail
 // with the same exit_code
-pub fn (p CommandPair) expected_failure(options string) ?os.Result {
+pub fn (p CommandPair) expected_failure(options string) !os.Result {
 	ores := os.execute('${p.original} ${options}')
 	if ores.exit_code == 0 {
 		return DidNotFailError{

--- a/src/numfmt/numfmt_test.v
+++ b/src/numfmt/numfmt_test.v
@@ -31,11 +31,11 @@ fn test_number_grouping() {
 
 fn test_numfmt() {
 	mut app := App{}
-	assert numfmt('2K', mut app, Options{}) or {} == '2000'
-	assert numfmt('-2M', mut app, Options{}) or {} == '-2000000'
-	assert numfmt('-2.0M', mut app, Options{ grouping: true }) or {} == '-2,000,000'
-	assert numfmt('20G', mut app, Options{}) or {} == '20000000000'
-	assert numfmt('20G', mut app, Options{ grouping: true }) or {} == '20,000,000,000'
+	assert numfmt('2K', mut app, Options{}) or { '' } == '2000'
+	assert numfmt('-2M', mut app, Options{}) or { '' } == '-2000000'
+	assert numfmt('-2.0M', mut app, Options{ grouping: true }) or { '' } == '-2,000,000'
+	assert numfmt('20G', mut app, Options{}) or { '' } == '20000000000'
+	assert numfmt('20G', mut app, Options{ grouping: true }) or { '' } == '20,000,000,000'
 }
 
 fn test_fields() {
@@ -46,19 +46,19 @@ fn test_fields() {
 
 fn test_to_options() {
 	mut app := App{}
-	assert numfmt('200000', mut app, Options{ to: 'si' }) or {} == '200k'
-	assert numfmt('2000000', mut app, Options{ to: 'si' }) or {} == '2.0m'
-	assert numfmt('200000', mut app, Options{ to: 'iec' }) or {} == '196K'
-	assert numfmt('2000000', mut app, Options{ to: 'iec' }) or {} == '2.0M'
-	assert numfmt('200000', mut app, Options{ to: 'iec-i' }) or {} == '196Ki'
-	assert numfmt('2000000', mut app, Options{ to: 'iec-i' }) or {} == '2.0Mi'
-	assert numfmt('2000000', mut app, Options{ to: 'none' }) or {} == '2000000'
+	assert numfmt('200000', mut app, Options{ to: 'si' }) or { '' } == '200k'
+	assert numfmt('2000000', mut app, Options{ to: 'si' }) or { '' } == '2.0m'
+	assert numfmt('200000', mut app, Options{ to: 'iec' }) or { '' } == '196K'
+	assert numfmt('2000000', mut app, Options{ to: 'iec' }) or { '' } == '2.0M'
+	assert numfmt('200000', mut app, Options{ to: 'iec-i' }) or { '' } == '196Ki'
+	assert numfmt('2000000', mut app, Options{ to: 'iec-i' }) or { '' } == '2.0Mi'
+	assert numfmt('2000000', mut app, Options{ to: 'none' }) or { '' } == '2000000'
 
-	assert numfmt('200000.1', mut app, Options{ to: 'si' }) or {} == '201k'
-	assert numfmt('2000000.2', mut app, Options{ to: 'si' }) or {} == '2.1m'
-	assert numfmt('200000.3', mut app, Options{ to: 'iec' }) or {} == '196K'
-	assert numfmt('2000000.4', mut app, Options{ to: 'iec' }) or {} == '2.0M'
-	assert numfmt('200000.5', mut app, Options{ to: 'iec-i' }) or {} == '196Ki'
-	assert numfmt('2000000.6', mut app, Options{ to: 'iec-i' }) or {} == '2.0Mi'
-	assert numfmt('2000000.6', mut app, Options{ to: 'none' }) or {} == '2000001'
+	assert numfmt('200000.1', mut app, Options{ to: 'si' }) or { '' } == '201k'
+	assert numfmt('2000000.2', mut app, Options{ to: 'si' }) or { '' } == '2.1m'
+	assert numfmt('200000.3', mut app, Options{ to: 'iec' }) or { '' } == '196K'
+	assert numfmt('2000000.4', mut app, Options{ to: 'iec' }) or { '' } == '2.0M'
+	assert numfmt('200000.5', mut app, Options{ to: 'iec-i' }) or { '' } == '196Ki'
+	assert numfmt('2000000.6', mut app, Options{ to: 'iec-i' }) or { '' } == '2.0Mi'
+	assert numfmt('2000000.6', mut app, Options{ to: 'none' }) or { '' } == '2000001'
 }


### PR DESCRIPTION
I was running `make test` on a Linux machine that I have access to, v version is 0.4.8 ae4a904, and a majority of the tests failed until I made the changes in this pull request.  Now only 2 tests fail, arch and sync.  arch because I don't have a native arch command on this machine.  sync, because of some confusion v has about importing the sync module and the test appears to be attempting to import the source of the sync program instead of the sync module from vlib.  I haven't had time to sort that out yet.

My ultimate goal is getting these programs to compile under FreeBSD and I wanted to have the Linux programs and tests to compare with.  I am going to have to re-arrange the utmp related code as FreeBSD removed utmp as of version 9.0 but it does have utmpx.  The command line parameters are a little different from their Linux counterparts in some cases.  Is the goal of coreutils to have the same commands, including all the command line parameters, be the same across all OS's or is the goal to have the commands,  including all the command line parameters, match the way they are on the target OS?

