### PR TITLE
Make testing with the multi-binary platform independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: |
           # Run tests
-          cd coreutils && v USE_MULTI_BINARY_TO_TEST=coreutils test .
+          cd coreutils && USE_MULTI_BINARY_TO_TEST=coreutils v test .
 
   ubuntu-fast-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           echo "adding '${PWD}' to PATH"
           echo "${PWD}" >> $GITHUB_PATH
       - name: Download uutils/coreutils
-        uses: engineerd/configurator@v0.0.8
+        uses: engineerd/configurator@v0.0.10 
         with:
           name: 'coreutils.exe'
           url: 'https://github.com/uutils/coreutils/releases/download/0.0.17/coreutils-0.0.17-x86_64-pc-windows-msvc.zip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Build and Test
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   winos-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Build and Test
 
-on:
-  workflow_dispatch:
+on: [push, pull_request]
 
 jobs:
   winos-test:
@@ -59,7 +58,7 @@ jobs:
         shell: bash
         run: |
           # Run tests
-          cd coreutils && v test .
+          cd coreutils && v USE_MULTI_BINARY_TO_TEST=coreutils test .
 
   ubuntu-fast-build:
     runs-on: ubuntu-latest
@@ -75,7 +74,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: coreutils
-
       - name: V doctor
         run: v doctor
       - name: Ensure everything is formatted
@@ -101,7 +99,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: coreutils
-
       - name: Build all with -prod
         run: cd coreutils && v run build.vsh -prod
       - name: Run tests
@@ -121,10 +118,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: coreutils
-
       - name: Build all
         run: cd coreutils && v run build.vsh
-
       - name: Native utils diagnostics (before GNU coreutils)
         run: |
           sleep --version
@@ -133,6 +128,5 @@ jobs:
         uses: ShenTengTu/setup-gnu-coreutils-action@v1
       - name: Test GNU coreutils uptime
         run: uptime --version
-
       - name: Run tests
         run: cd coreutils && GNU_COREUTILS_INSTALLED=1 make test

--- a/common/testing/testing.v
+++ b/common/testing/testing.v
@@ -109,6 +109,7 @@ pub fn command_fails(cmd string) !os.Result {
 }
 
 const gnu_coreutils_installed = os.getenv('GNU_COREUTILS_INSTALLED').int() == 1
+const use_multi_binary_to_test = os.getenv('USE_MULTI_BINARY_TO_TEST')
 
 // same_results/2 executes the given commands, and ensures that
 // their results are exactly the same, both for their exit codes,


### PR DESCRIPTION
Up to now, the testing logic was that if we test in Windows, the multi-binary gets used, otherwise it's the individual command line utils. Disentangling platform and multi-binary use creates flexibility to the future, such as: 
- set up tests with the multi-binary on *nix
- use other versions of Windows coreutils (like GNU instead of the current Rust version from uutils) to test against

... and the code is a little cleaner with fewer `$if !windows` :)