### PR TITLE
Fix sort tests "test_numeric" and "test_numeric_reverse"

### DIFF
--- a/src/sort/sort.v
+++ b/src/sort/sort.v
@@ -136,10 +136,9 @@ fn sort_general_numeric(mut lines []string, options Options) {
 const minus_infinity = f64(-0xFFFFFFFFFFFFFFF)
 
 fn numeric_rest(s string) (f64, string) {
-	mut num := 0.0
-	mut rest := s
 	mut allow_blanks := true
 	mut allow_sign := true
+	mut end := s.len
 	for i := 0; i < s.len; i++ {
 		c := s[i]
 		if allow_blanks && c == space {
@@ -155,9 +154,12 @@ fn numeric_rest(s string) (f64, string) {
 			allow_blanks = false
 			continue
 		}
-		num = strconv.atof64(s[0..i]) or { minus_infinity }
-		rest = s[i..].clone()
+		// non-numeric char found
+		end = i
+		break
 	}
+	num := strconv.atof64(s[0..end]) or { minus_infinity }
+	rest := s[end..]
 	return num, rest
 }
 


### PR DESCRIPTION
Partial fix of #190, this should be two issues instead of one.

The lines are sorted lexicographically instead of numerically. The numeric_rest function in sort.v incorrectly parses numeric prefixes, leading to all lines being treated as having minus_infinity value.

```
$ v -stats test .
checker summary: 0 V errors, 0 V warnings, 12 V notices
        V  source  code size:      35097 lines,     162656 tokens,     963970 bytes,   378 types,    15 modules,   163 files
generated  target  code size:      12271 lines,     472864 bytes
compilation took: 708.468 ms, compilation speed: 49539 vlines/s, cgen threads: 7
running tests in: /Users/sheat/Documents/Projects/v/coreutils/src/sort/sort_test.v
      OK    [ 1/13]     0.622 ms    NO asserts | main.testsuite_begin()
      OK    [ 2/13]     0.041 ms     1 assert  | main.test_no_options()
      OK    [ 3/13]     0.022 ms     1 assert  | main.test_reverse()
      OK    [ 4/13]     0.022 ms     1 assert  | main.test_ignore_case()
      OK    [ 5/13]     0.021 ms     1 assert  | main.test_ignore_case_reverse()
      OK    [ 6/13]     0.022 ms     1 assert  | main.test_ignore_leading_blanks()
      OK    [ 7/13]     0.021 ms     1 assert  | main.test_ignore_leading_blanks_reverse()
      OK    [ 8/13]     0.032 ms     1 assert  | main.test_dictionary_order()
      OK    [ 9/13]     0.024 ms     1 assert  | main.test_dictionary_order_everse()
      OK    [10/13]     0.023 ms     1 assert  | main.test_non_printing()
      OK    [11/13]     0.025 ms     1 assert  | main.test_non_printing_reverse()
      OK    [12/13]     0.047 ms     1 assert  | main.test_numeric()
      OK    [13/13]     0.034 ms     1 assert  | main.test_numeric_reverse()
     Summary for running V tests in "sort_test.v": 12 passed, 12 total. Elapsed time: 1 ms.

        V  source  code size:      35033 lines,     162489 tokens,     962536 bytes,   378 types,    15 modules,   163 files
generated  target  code size:      12212 lines,     464041 bytes
compilation took: 708.530 ms, compilation speed: 49444 vlines/s, cgen threads: 7
running tests in: /Users/sheat/Documents/Projects/v/coreutils/src/sort/sort_keys_test.v
      OK    [ 1/11]     0.635 ms    NO asserts | main.testsuite_begin()
      OK    [ 2/11]     0.000 ms     1 assert  | main.test_parse_simple_field()
      OK    [ 3/11]     0.000 ms     1 assert  | main.test_parse_field_column()
      OK    [ 4/11]     0.001 ms     1 assert  | main.test_parse_field_column_sort_field()
      OK    [ 5/11]     0.001 ms     1 assert  | main.test_parse_field_column_sort_field_column()
      OK    [ 6/11]     0.002 ms     1 assert  | main.test_find_field_simple()
      OK    [ 7/11]     0.001 ms     1 assert  | main.test_find_field_no_f2()
      OK    [ 8/11]     0.001 ms     1 assert  | main.test_find_field_full_spec()
      OK    [ 9/11]     0.077 ms     1 assert  | main.test_sort_simple_column()
      OK    [10/11]     0.054 ms     1 assert  | main.test_sort_full_spec()
      OK    [11/11]     0.062 ms     1 assert  | main.test_sort_numeric_simple()
     Summary for running V tests in "sort_keys_test.v": 10 passed, 10 total. Elapsed time: 0 ms.

 OK    [1/2]  1074.779 ms /Users/sheat/Documents/Projects/v/coreutils/src/sort/sort_keys_test.v
 OK    [2/2]  1074.738 ms /Users/sheat/Documents/Projects/v/coreutils/src/sort/sort_test.v
--------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 2 passed, 2 total. Elapsed time: 1075 ms, on 2 parallel jobs. Comptime: 0 ms. Runtime: 2149 ms.
```